### PR TITLE
Arms encumbrance no longer affects crafting speed, except when it's encumbrance from integrated armor

### DIFF
--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -5,6 +5,7 @@ Added possibility to configure forest density in game options
 Melee weapons won't be damaged anymore by misses
 Defense bots, turrets, and mi-go scout will now fire at moving vehicles even if they don't see player controlling said vehicles
 Prompt player to return to main menu on character death (aka avoid permadeath)
+Hands encumbrance no longer affects crafting speed, except when it's encumbrance from integrated armor
 
 ## Content
 Returned back previously obsoleted SPIW weapons

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -84,6 +84,8 @@ static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 
 static const efftype_id effect_contacts( "contacts" );
 
+static const flag_id json_flag_INTEGRATED( "INTEGRATED" );
+
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_plut_cell( "plut_cell" );
 
@@ -265,9 +267,13 @@ static float workbench_crafting_speed_multiplier( const Character &you, const it
 
 float Character::crafting_speed_multiplier( const recipe &rec ) const
 {
+    const bool integrated_armor_affects_hands =
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_l" ) ) ||
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_r" ) );
+
     const float result = morale_crafting_speed_multiplier( rec ) *
                          lighting_craft_speed_multiplier( rec ) *
-                         get_limb_score( limb_score_manip );
+                         integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1;
     add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %.1f, crafting speed multiplier %1f",
                    get_limb_score( limb_score_manip ), result );
 
@@ -289,8 +295,12 @@ float Character::crafting_speed_multiplier( const item &craft,
     const float morale_multi = morale_crafting_speed_multiplier( rec );
     const float mut_multi = mutation_value( "crafting_speed_multiplier" );
 
+    const bool integrated_armor_affects_hands =
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_l" ) ) ||
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_r" ) );
+
     const float total_multi = light_multi * bench_multi * morale_multi * mut_multi *
-                              get_limb_score( limb_score_manip );
+                              integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1;
 
     if( light_multi <= 0.0f ) {
         add_msg_if_player( m_bad, _( "You can no longer see well enough to keep crafting." ) );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -273,7 +273,7 @@ float Character::crafting_speed_multiplier( const recipe &rec ) const
 
     const float result = morale_crafting_speed_multiplier( rec ) *
                          lighting_craft_speed_multiplier( rec ) *
-                         integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1;
+                         ( integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1 );
     add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %.1f, crafting speed multiplier %1f",
                    get_limb_score( limb_score_manip ), result );
 
@@ -300,7 +300,7 @@ float Character::crafting_speed_multiplier( const item &craft,
         get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_r" ) );
 
     const float total_multi = light_multi * bench_multi * morale_multi * mut_multi *
-                              integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1;
+                              ( integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1 );
 
     if( light_multi <= 0.0f ) {
         add_msg_if_player( m_bad, _( "You can no longer see well enough to keep crafting." ) );


### PR DESCRIPTION
#### Summary
Features "Hands encumbrance no longer affects crafting speed, except when it's encumbrance from integrated armor"

#### Purpose of change
Currently player has to manually take off gloves or similar hands-covering clothing/armor before crafting (and wear them once again after the crafting), which only increases keypresses. Also it differs from our other conventions, such as virtual walking in 6-tile radius during crafting, or that we don't need to take off masks and other mouth-covering clothing/armor during eating.

#### Describe the solution
Only calculate decrease of crafting speed due to arms encumbrance if it's the encumbrance from integrated armor. Otherwise, presume that player character automatically takes off gloves and the like before crafting and wears them back after crafting.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Wore mittens, checked amount of time required to craft zweitimber (no increase), crafted it, noticed that time spent is correct.
Took off mittens, debug-get myself bark mutation, checked amount of time required to craft zweitimber (30% increase), crafted it, noticed that time spent is correct.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->