### PR TITLE
Monsters won't shoot at vehicles they can't see

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -837,6 +837,9 @@ static vehicle *find_target_vehicle( monster &z, int range )
     map &here = get_map();
     vehicle *chosen = nullptr;
     for( wrapped_vehicle &v : here.get_vehicles() ) {
+        if( !z.sees( v.pos ) ) {
+            continue;
+        }
         if( !fov_3d && v.pos.z != z.pos().z ) {
             continue;
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Monsters won't shoot at vehicles they can't see"

#### Purpose of change
Playtesting revealed that monsters with "shoot-at-vehicles" ability will shoot at vehicles even if they don't normally see them.

#### Describe the solution
Added a check for visibility of vehicle before making said vehicle a target.

#### Describe alternatives you've considered
None.

#### Testing
Made a night. Get myself a bicycle. Debug-spawned a turret in 10 tiles away from me. Started moving on the bicycle. No shooting at me until I drove inside its night vision range.

#### Additional context
None.