### PR TITLE
Moved martial arts manuals to its own new item category

### DIFF
--- a/data/json/item_category.json
+++ b/data/json/item_category.json
@@ -134,6 +134,13 @@
     "sort_rank": -7
   },
   {
+    "id": "ma_manuals",
+    "type": "ITEM_CATEGORY",
+    "name": { "str": "MARTIAL ARTS MANUALS" },
+    "zone": "LOOT_MA_MANUALS",
+    "sort_rank": -6
+  },
+  {
     "id": "chems",
     "type": "ITEM_CATEGORY",
     "name": { "str": "CHEMICAL STUFF" },

--- a/data/json/items/book/abstract.json
+++ b/data/json/items/book/abstract.json
@@ -357,7 +357,7 @@
   {
     "abstract": "book_martial",
     "type": "BOOK",
-    "category": "manuals",
+    "category": "ma_manuals",
     "name": { "str": "martial art manual" },
     "weight": "150 g",
     "volume": "250 ml",

--- a/data/json/loot_zones.json
+++ b/data/json/loot_zones.json
@@ -112,6 +112,13 @@
     "description": "Destination for instructional books and magazines."
   },
   {
+    "id": "LOOT_MA_MANUALS",
+    "type": "LOOT_ZONE",
+    "name": "Loot: Martial arts manuals",
+    "can_be_personal": true,
+    "description": "Destination for manuals for martial arts."
+  },
+  {
     "id": "LOOT_MODS",
     "type": "LOOT_ZONE",
     "name": "Loot: Mods",

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2621,6 +2621,11 @@ void options_manager::add_options_world_default()
              0.0, 10.0, 1.0, 0.01
            );
 
+        add( "SPAWN_RATE_ma_manuals", page_id, to_translation( "Martial arts manuals" ),
+             to_translation( "Spawn rate for items from MARTIAL ARTS MANUALS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
         add( "SPAWN_RATE_books", page_id, to_translation( "Books" ),
              to_translation( "Spawn rate for items from BOOKS category." ),
              0.0, 10.0, 1.0, 0.01


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #26.

#### Describe the solution
- Added a new `Martial arts manuals` item category and assigned all martial arts book to this category
- Added a new loot zone for this category
- Added a new point in `Item spawn scaling factor` option group

#### Describe alternatives you've considered
None

#### Testing
Got The Spirit of Aikido, examined it and checked item category. Opened game options to check that this new category is in `Item spawn scaling factor` option group. Opened zone manager to check that loot zone for this new category is available.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/229617018-df8c3f41-13d9-4c8f-9940-e0d2dfa6a522.png)

![изображение](https://user-images.githubusercontent.com/11132525/229617283-e9d85385-94f0-4590-a380-efb09ef29320.png)
