### PR TITLE
Player character won't fail at crafting items from very easy or very fast recipes

### DIFF
--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -6,6 +6,7 @@ Melee weapons won't be damaged anymore by misses
 Defense bots, turrets, and mi-go scout will now fire at moving vehicles even if they don't see player controlling said vehicles
 Prompt player to return to main menu on character death (aka avoid permadeath)
 Hands encumbrance no longer affects crafting speed, except when it's encumbrance from integrated armor
+Player character won't fail at crafting items from very fast (time to craft <=10 seconds) or very easy (difficulty <=1)
 
 ## Content
 Returned back previously obsoleted SPIW weapons

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1215,6 +1215,14 @@ static float normal_roll_chance( float center, float stddev, float difficulty )
 
 float Character::recipe_success_chance( const recipe &making ) const
 {
+    const time_duration max_duration = 10_seconds;
+
+    if( making.difficulty <= 1 ||
+        making.time_to_craft( get_player_character(),
+                              recipe_time_flag::ignore_proficiencies ) <= max_duration ) {
+        return 1.f;
+    }
+
     // We calculate the failure chance of a recipe by performing a normal roll with a given
     // standard deviation and center, then subtracting a "final difficulty" score from that.
     // If that result is above 1, there is no chance of failure.
@@ -1225,6 +1233,14 @@ float Character::recipe_success_chance( const recipe &making ) const
 
 float Character::item_destruction_chance( const recipe &making ) const
 {
+    const time_duration max_duration = 10_seconds;
+
+    if( making.difficulty <= 1 ||
+        making.time_to_craft( get_player_character(),
+                              recipe_time_flag::ignore_proficiencies ) <= max_duration ) {
+        return 0.f;
+    }
+
     // If a normal roll with these parameters rolls over 1, we will not have a catastrophic failure
     // If we roll under one, we will
     craft_roll_data data = recipe_failure_roll_data( making );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1160,6 +1160,14 @@ Character::craft_roll_data Character::recipe_failure_roll_data( const recipe &ma
 
 float Character::crafting_success_roll( const recipe &making ) const
 {
+    const time_duration max_duration = 10_seconds;
+
+    if( making.difficulty <= 1 ||
+        making.time_to_craft( get_player_character(),
+                              recipe_time_flag::ignore_proficiencies ) <= max_duration ) {
+        return 1.f;
+    }
+
     craft_roll_data data = recipe_success_roll_data( making );
     float craft_roll = std::max( normal_roll( data.center, data.stddev ), 0.0 );
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -722,10 +722,10 @@ TEST_CASE( "crafting_failure_rates_match_calculated", "[crafting][random]" )
     const recipe_id armor_qt_lightplate( "armor_qt_lightplate_test_no_tools" );
 
     // Skill zero recipes
-    test_chances_for( makeshift_crowbar, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
-    test_chances_for( meat_cooked, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
-    test_chances_for( club_wooden_large, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
-    test_chances_for( nailboard, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
+    test_chances_for( makeshift_crowbar, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f );
+    test_chances_for( meat_cooked, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f );
+    test_chances_for( club_wooden_large, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f );
+    test_chances_for( nailboard, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f );
     // Recipes requring various degrees of skill and proficiencies
     test_chances_for( cudgel, 82.5, 72.f, 50.f, 50.f, 21.f, 21.f, 2.25 );
     test_chances_for( pumpkin_muffins, 92.5, 82.f, 67.f, 50.f, 43.f, 21.f, 2.25 );


### PR DESCRIPTION
#### Summary
Balance "Player character won't fail at crafting items from very easy or very fast recipes"

#### Purpose of change
Previously there was always a chance to fail while crafting, even for recipes that it should be impossible to fail. For example, to craft washing kit, one needs only to combine washing board and a rag. Even a complete noob with 0 in all skills shouldn't fail at such a task. 

![изображение](https://user-images.githubusercontent.com/11132525/230075236-b3d25ef6-2daa-4868-b05e-ddb3cc99fc59.png)
However, right now the chance to get a minor failure for this recipe for standard 8/8/8/8 character is a whopping 50%. What's worse, there is an overwhelming chance of more than 9% to completely destroy either washing board or a rag when combining them. I find this silly and unfun.

#### Describe the solution
If difficulty of the recipe is 1 or lower, or time to craft is 10 seconds or less, then there is no chance to fail the craft.

#### Describe alternatives you've considered
None.

#### Testing
Get myself tons of washing boards and tons of rags. Crafted tons of washing kits with standard character. No failures at crafting.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/230076257-202fc939-974b-4d55-acb8-b51eb1a9e539.png)

For comparison, crafting more difficult recipes still may still fail
![изображение](https://user-images.githubusercontent.com/11132525/230076613-2174008b-05b4-41c2-9e58-96c419ece1f4.png)
