### PR TITLE
Helicopter pilot training CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1056,6 +1056,17 @@
     "time": "1 s"
   },
   {
+    "id": "bio_heli",
+    "type": "bionic",
+    "name": { "str": "Helicopter Pilot Training" },
+    "description": "Bionic processors and databanks, loaded with experimental helicopter handling training program, are surgically integrated into your nervous system.  While active, this module allows you to fly helicopters.",
+    "occupied_bodyparts": [ [ "head", 3 ] ],
+    "act_cost": "20 J",
+    "react_cost": "20 J",
+    "time": "1 s",
+    "flags": [ "BIONIC_TOGGLED" ]
+  },
+  {
     "id": "bio_hydraulics",
     "type": "bionic",
     "name": { "str": "Hydraulic Muscles" },

--- a/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
@@ -152,6 +152,7 @@
     "subtype": "distribution",
     "items": [
       [ "bio_climate", 5 ],
+      [ "bio_heli", 5 ],
       [ "bio_digestion", 15 ],
       [ "bio_evap", 15 ],
       [ "bio_fingerhack", 20 ],

--- a/data/json/itemgroups/bionics.json
+++ b/data/json/itemgroups/bionics.json
@@ -174,6 +174,7 @@
       [ "bio_probability_travel", 10 ],
       [ "bio_power_armor_interface", 10 ],
       [ "bio_cqb", 5 ],
+      [ "bio_heli", 5 ],
       [ "bio_blade", 2 ],
       [ "bio_speed", 2 ],
       [ "bio_adrenaline", 10 ],

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -522,6 +522,18 @@
     "installation_data": "AID_bio_heatsink"
   },
   {
+    "id": "bio_heli",
+    "copy-from": "bionic_general",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Helicopter Pilot Training CBM" },
+    "looks_like": "bio_int_enhancer",
+    "description": "A set of bionic processors and databanks, loaded with experimental helicopter handling training program, are surgically integrated into your nervous system.  While active, this module allows you to fly helicopters.",
+    "price": 220000,
+    "price_postapoc": 3000,
+    "weight": "250 g",
+    "difficulty": 8
+  },
+  {
     "id": "bio_hydraulics",
     "copy-from": "bionic_general_npc_usable",
     "type": "BIONIC_ITEM",

--- a/data/json/monsterdrops/zombie_military_pilot.json
+++ b/data/json/monsterdrops/zombie_military_pilot.json
@@ -13,7 +13,8 @@
       { "group": "wallets_military", "prob": 25 },
       { "group": "military_patrol_food", "prob": 30 },
       { "group": "pocket_cigar", "prob": 15 },
-      { "group": "misc_smoking_legal", "prob": 30 }
+      { "group": "misc_smoking_legal", "prob": 30 },
+      { "item": "bio_heli", "prob": 1 }
     ]
   }
 ]

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -263,7 +263,14 @@
     "type": "item_group",
     "id": "EXODII_CBM_unlocks_weapons_light",
     "//": "To get items from this group in the Exodii CBM store requires finishing missions for their faction and earning their trust",
-    "items": [ [ "bio_blade", 10 ], [ "bio_claws", 10 ], [ "bio_cqb", 10 ], [ "bio_flashbang", 10 ], [ "bio_razors", 10 ] ]
+    "items": [
+      [ "bio_blade", 10 ],
+      [ "bio_claws", 10 ],
+      [ "bio_cqb", 10 ],
+      [ "bio_flashbang", 10 ],
+      [ "bio_razors", 10 ],
+      [ "bio_heli", 10 ]
+    ]
   },
   {
     "type": "item_group",

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -112,8 +112,8 @@ static const activity_id ACT_WAIT( "ACT_WAIT" );
 static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
 static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 
-static const bionic_id bio_remote( "bio_remote" );
 static const bionic_id bio_heli( "bio_heli" );
+static const bionic_id bio_remote( "bio_remote" );
 
 static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_incorporeal( "incorporeal" );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -113,6 +113,7 @@ static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
 static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 
 static const bionic_id bio_remote( "bio_remote" );
+static const bionic_id bio_heli( "bio_heli" );
 
 static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_incorporeal( "incorporeal" );
@@ -484,7 +485,8 @@ static void pldrive( const tripoint &p )
         }
     }
     if( p.z != 0 ) {
-        if( !player_character.has_proficiency( proficiency_prof_helicopter_pilot ) ) {
+        if( !player_character.has_proficiency( proficiency_prof_helicopter_pilot ) &&
+            !player_character.has_active_bionic( bio_heli ) ) {
             player_character.add_msg_if_player( m_info, _( "You have no idea how to make the vehicle fly." ) );
             return;
         }


### PR DESCRIPTION
#### Summary
Content "Helicopter pilot training CBM"

#### Purpose of change
Add a way to be able to fly helicopters for characters even without the proficiency..

#### Describe the solution
- Added the bionic and bionic item. Bionic cost, difficulty, and power cost are all taken from CQB bionic.
- Made bionic spawn: as a harvest of zomborgs, as a harvest of military zombie pilots, as a part of Exodii merchandise, and also as random roll for `bionics` item group.
- Added a check for this bionic into `pldrive` function.

#### Describe alternatives you've considered
Make a computer which will learn you to fly through some sci-fi mumbo-jumbo.

#### Testing
Got Apache, turned on its engines, tried to ascend. Fail.
Got this bionic, activated it, tried to ascend. Success.

#### Additional context
None.