### PR TITLE
Added ability to remove plants from planters without destroying planter

### DIFF
--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -183,14 +183,15 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
+      "str_max": 10,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 8,
+      "furn_set": "f_planter",
       "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
+        { "item": "withered", "count": [ 2, 8 ] },
+        { "item": "leaves", "count": [ 4, 16 ] },
+        { "item": "twig", "count": [ 1, 5 ] }
       ]
     },
     "plant_data": { "transform": "f_planter", "base": "f_planter" }
@@ -217,14 +218,15 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
+      "str_max": 10,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 8,
+      "furn_set": "f_planter",
       "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
+        { "item": "withered", "count": [ 2, 8 ] },
+        { "item": "leaves", "count": [ 4, 16 ] },
+        { "item": "twig", "count": [ 1, 5 ] }
       ]
     },
     "plant_data": { "transform": "f_planter_harvest", "base": "f_planter" }
@@ -250,16 +252,13 @@
       ]
     },
     "bash": {
-      "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
-      "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
-      ]
+      "str_min": 2,
+      "str_max": 6,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 4,
+      "furn_set": "f_planter",
+      "items": [ { "item": "withered", "count": [ 1, 2 ] }, { "item": "leaves", "count": [ 1, 2 ] } ]
     },
     "plant_data": { "transform": "f_planter_seedling", "base": "f_planter" }
   },
@@ -284,15 +283,16 @@
       ]
     },
     "bash": {
-      "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
+      "str_min": 4,
+      "str_max": 8,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 6,
+      "furn_set": "f_planter",
       "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
+        { "item": "withered", "count": [ 1, 2 ] },
+        { "item": "leaves", "count": [ 2, 6 ] },
+        { "item": "twig", "count": [ 0, 1 ] }
       ]
     },
     "plant_data": { "transform": "f_planter_mature", "base": "f_planter" }


### PR DESCRIPTION
#### Summary
Content "Added ability to remove plants from planters without destroying planter"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Ported https://github.com/CleverRaven/Cataclysm-DDA/pull/64811 by @stubkan.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->