### PR TITLE
Neutral monsters will ignore moving vehicles with visible driver until they are moving closer than 5 tiles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -483,6 +483,14 @@ std::set<tripoint_bub_ms> map::get_moving_vehicle_targets( const Creature &z, in
         if( rl_dist( zpos, tripoint_bub_ms( v.pos ) ) > max_range + 40 ) {
             continue; // coarse distance filter, 40 = ~24 * sqrt(2) - rough max diameter of a vehicle
         }
+
+        // Neutral monsters will ignore moving vehicles with visible driver until they are moving closer than 5 tiles
+        if( z.sees( get_player_character() ) &&
+            z.attitude_to( get_player_character() ) == Creature::Attitude::NEUTRAL &&
+            rl_dist( zpos, tripoint_bub_ms( v.pos ) ) >= 5 ) {
+            continue;
+        }
+
         for( const vpart_reference &vpr : v.v->get_all_parts() ) {
             const tripoint_bub_ms vppos = static_cast<tripoint_bub_ms>( vpr.pos() );
             if( rl_dist( zpos, vppos ) > max_range ) {


### PR DESCRIPTION
#### Summary
Balance "Neutral monsters will ignore moving vehicles with visible driver until they are moving closer than 5 tiles"

#### Purpose of change
* Closes #51.

#### Describe the solution
Neutral monsters will ignore moving vehicles with visible driver until they are moving closer than 5 tiles.

#### Describe alternatives you've considered
Change tolerable distance to 3? 7?

#### Testing
Hostile turret: 
- sees driver - attacks driver
- doesn't see driver - attacks vehicle

Neutral turret:
- sees driver - ignores driver/vehicle if farther than 5 tiles. Attacks vehicle if closer than 5 tiles
- doesn't see driver - attacks vehicle

Friendly turret:
- sees driver - ignores driver/vehicle
- doesn't see driver - ignores driver/vehicle

#### Additional context
None.