### PR TITLE
Characters with Infection Immune trait no longer need to sterilize bionics prior to installation

### DIFF
--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -8,13 +8,13 @@ Prompt player to return to main menu on character death (aka avoid permadeath)
 Hands encumbrance no longer affects crafting speed, except when it's encumbrance from integrated armor
 If player is acid-protected, allow auto-pulping of acidic zombies 
 Player character won't fail at crafting items from very fast (time to craft <=10 seconds) or very easy (difficulty <=1) recipes
+Characters with Infection Immune trait no longer need to sterilize bionics prior to installation
 
 ## Content
 Returned back previously obsoleted SPIW weapons
 Added Helicopter Pilot Training CBM which allows flying helicopters even without proficiency
 Added ability to remove plants from planters without destroying planter
 Added overhead light to three default shelters
-
 
 ## Interface
 Item categories spawn rate is now located in game options rather than hidden in json

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -163,6 +163,7 @@ static const json_character_flag json_flag_BIONIC_POWER_SOURCE( "BIONIC_POWER_SO
 static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 static const json_character_flag json_flag_BIONIC_WEAPON( "BIONIC_WEAPON" );
 static const json_character_flag json_flag_ENHANCED_VISION( "ENHANCED_VISION" );
+static const json_character_flag json_flag_INFECTION_IMMUNE( "INFECTION_IMMUNE" );
 
 static const material_id fuel_type_metabolism( "metabolism" );
 static const material_id fuel_type_sun_light( "sunlight" );
@@ -2314,7 +2315,7 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
         const std::string msg = by_autodoc ? _( "/!\\ CBM is highly contaminated. /!\\" ) :
                                 _( "CBM is filthy." );
         return ret_val<void>::make_failure( msg );
-    } else if( it->has_flag( flag_NO_STERILE ) ) {
+    } else if( it->has_flag( flag_NO_STERILE ) && !has_flag( json_flag_INFECTION_IMMUNE ) ) {
         const std::string msg = by_autodoc ?
                                 // NOLINTNEXTLINE(cata-text-style): single space after the period for symmetry
                                 _( "/!\\ CBM is not sterile. /!\\ Please use autoclave to sterilize." ) :


### PR DESCRIPTION
#### Summary
Features "Characters with Infection Immune trait no longer need to sterilize bionics prior to installation"

#### Purpose of change
Characters with Infection Immune trait are, well, immune to infections, including those which can transmit via installation of non-sterile bionics. This change feels plausible and make trait in question more valuable.

#### Describe the solution
Added check for the trait in `Character::is_installable` function.

#### Describe alternatives you've considered
- Characters with Disease Immune should gain this advantage too? On the other hand, "disease" in this context only relates to viral diseases like common cold and flu, and I'm not sure whether we should take other viral pathogens into consideration since we don't simulate them.
- Permit installing not only non-sterile bionics, but also filthy ones?

#### Testing
Got Infection Immune trait. Got non-sterile bionic. Found autodoc. Tried to install the bionic. Success.

#### Additional context
None.