### PR TITLE
Try to infect player only on feral/NPC cough

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -313,6 +313,7 @@ static const json_character_flag json_flag_MYOPIC( "MYOPIC" );
 static const json_character_flag json_flag_MYOPIC_IN_LIGHT( "MYOPIC_IN_LIGHT" );
 static const json_character_flag json_flag_NIGHT_VISION( "NIGHT_VISION" );
 static const json_character_flag json_flag_NON_THRESH( "NON_THRESH" );
+static const json_character_flag json_flag_NO_DISEASE( "NO_DISEASE" );
 static const json_character_flag json_flag_NO_RADIATION( "NO_RADIATION" );
 static const json_character_flag json_flag_NO_THIRST( "NO_THIRST" );
 static const json_character_flag json_flag_PRED2( "PRED2" );
@@ -4988,14 +4989,23 @@ void Character::check_needs_extremes()
     }
 }
 
-void Character::get_sick( int contacts )
+bool Character::can_get_sick()
+{
+    avatar &you = get_avatar();
+    return !you.has_flag( json_flag_NO_DISEASE ) &&
+           !you.has_effect( effect_flu_immunity ) &&
+           !you.has_effect( effect_common_cold_immunity );
+}
+
+void Character::get_sick()
 {
     // Health is in the range [-200,200].
     // Diseases are half as common for every 50 health you gain.
     const float health_factor = std::pow( 2.0f, get_lifestyle() / 50.0f );
-    const float env_factor = 1.0f + std::pow( get_env_resist( body_part_mouth ), 0.3f ) / 2.0;
-    const int disease_rarity = static_cast<int>( health_factor + env_factor / contacts );
+    const float env_factor = 2.0f + std::pow( get_env_resist( body_part_mouth ), 0.3f );
+    const int disease_rarity = static_cast<int>( health_factor + env_factor );
     add_msg_debug( debugmode::DF_CHAR_HEALTH, "disease_rarity = %d", disease_rarity );
+
     if( one_in( disease_rarity ) ) {
         // Normal people get sick about 2-4 times/year.
         int base_diseases_per_year = 3;

--- a/src/character.h
+++ b/src/character.h
@@ -763,8 +763,10 @@ class Character : public Creature, public visitable
         void calc_sleep_recovery_rate( needs_rates &rates ) const;
         /** Kills the player if too hungry, stimmed up etc., forces tired player to sleep and prints warnings. */
         void check_needs_extremes();
-        /** Handles the chance to be infected by random diseases */
-        void get_sick( int contacts );
+        /** Checks if player can get sick with common cold or flu */
+        bool can_get_sick();
+        /** Handles the chance to be infected by common cold or flu */
+        void get_sick();
         /** Returns if the player has hibernation mutation and is asleep and well fed */
         bool is_hibernating() const;
         /** Maintains body temperature */

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -33,11 +33,8 @@ static const efftype_id effect_blisters( "blisters" );
 static const efftype_id effect_cig( "cig" );
 static const efftype_id effect_cold( "cold" );
 static const efftype_id effect_common_cold( "common_cold" );
-static const efftype_id effect_common_cold_immunity( "common_cold_immunity" );
 static const efftype_id effect_disinfected( "disinfected" );
-static const efftype_id effect_fake_common_cold( "fake_common_cold" );
 static const efftype_id effect_flu( "flu" );
-static const efftype_id effect_flu_immunity( "flu_immunity" );
 static const efftype_id effect_frostbite( "frostbite" );
 static const efftype_id effect_frostbite_recovery( "frostbite_recovery" );
 static const efftype_id effect_hot( "hot" );
@@ -68,7 +65,6 @@ static const json_character_flag json_flag_HEATSINK( "HEATSINK" );
 static const json_character_flag json_flag_HEAT_IMMUNE( "HEAT_IMMUNE" );
 static const json_character_flag json_flag_IGNORE_TEMP( "IGNORE_TEMP" );
 static const json_character_flag json_flag_LIMB_LOWER( "LIMB_LOWER" );
-static const json_character_flag json_flag_NO_DISEASE( "NO_DISEASE" );
 static const json_character_flag json_flag_NO_THIRST( "NO_THIRST" );
 
 static const trait_id trait_BARK( "BARK" );
@@ -330,34 +326,6 @@ void Character::update_body( const time_point &from, const time_point &to )
     const int thirty_mins = ticks_between( from, to, 30_minutes );
     if( thirty_mins > 0 ) {
         update_health();
-    }
-
-    const bool can_get_sick = !is_npc() && // NPCs are too dumb to handle infections now
-                              !has_flag( json_flag_NO_DISEASE ) && // In a shocking twist, disease immunity prevents diseases
-                              !has_effect( effect_flu_immunity ) && // While it's possible to get sick when you already are,
-                              !has_effect( effect_common_cold_immunity ); // it wouldn't be very fun.
-
-    if( can_get_sick && calendar::once_every( 1_turns ) ) {
-        map &here = get_map();
-        creature_tracker &creatures = get_creature_tracker();
-        int contacts = 0;
-
-        for( const tripoint &pos : here.points_in_radius( pos(), 1 ) ) {
-            if( monster *const mon = creatures.creature_at<monster>( pos ) ) {
-                if( mon->has_effect( effect_fake_common_cold ) ) {
-                    contacts++;
-                }
-            }
-            if( npc *const who = creatures.creature_at<npc>( pos ) ) {
-                if( who->has_effect( effect_fake_common_cold ) ) {
-                    contacts++;
-                }
-            }
-        }
-
-        if( contacts > 0 ) {
-            get_sick( contacts );
-        }
     }
 
     if( calendar::once_every( 10_minutes ) ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2950,6 +2950,15 @@ void monster::process_one_effect( effect &it, bool is_new )
     } else if( id == effect_fake_common_cold ) {
         if( calendar::once_every( time_duration::from_seconds( rng( 30, 300 ) ) ) ) {
             sounds::sound( pos(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc", "cough" );
+
+            avatar &you = get_avatar();
+            for( const tripoint &pos : get_map().points_in_radius( pos(), 1 ) ) {
+                if( you.can_get_sick() && pos == you.pos() ) { // No NPCs for now
+                    you.get_sick();
+                    break;
+                }
+            }
+
         }
     }
 }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -7,6 +7,7 @@
 
 #include "activity_handlers.h"
 #include "activity_type.h"
+#include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "character.h"
@@ -169,6 +170,14 @@ static void eff_fun_fake_common_cold( Character &u, effect & )
 {
     if( calendar::once_every( time_duration::from_seconds( rng( 30, 300 ) ) ) ) {
         u.cough( true );
+
+        avatar &you = get_avatar();
+        for( const tripoint &pos : get_map().points_in_radius( u.pos(), 1 ) ) {
+            if( you.can_get_sick() && pos == you.pos() ) { // No NPCs for now
+                you.get_sick();
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Resolve possible performance issues.

#### Describe the solution
Applied @LazyWizard's [suggestion](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/66#issuecomment-1522721352) and made checks for getting sick only roll when NPC or feral with `fake_common_cold` effect coughs.

Also, while I'm here, I slightly buffed environmental factor when determining player's chance to get sick as I felt that wearing no mouth protection at all and wearing a gas mask has almost the same effect when calculating this chance. 

#### Describe alternatives you've considered
None.

#### Testing
Built a cage for me and NPC with the effect. Waited for NPC to cough on me. 

#### Additional context
None.