### PR TITLE
Detailed information for stats on character creation menu

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1257,9 +1257,9 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                 mvwprintz( w_description, point_zero, ( read_spd == 100 ? COL_STAT_NEUTRAL :
                                                         ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ),
                            _( "Read times: %d%%" ), read_spd );
+                // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Persuade/lie skill: %i" ),
                            u.persuade_skill() );
-                // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Crafting bonus: %2d%%" ),
                            u.get_int() );
                 mvwprintz( w_description, point( 0, 4 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
@@ -1304,6 +1304,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                     mvwprintz( w_description, point_zero, COL_STAT_PENALTY, _( "Aiming penalty: -%d" ),
                                u.ranged_per_mod() );
                 }
+                // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Persuade/lie skill: %i" ),
                            u.persuade_skill() );
                 mvwprintz( w_description, point( 0, 3 ), COL_STAT_NEUTRAL, _( "Affects:" ) );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1072,7 +1072,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
     catacurses::window w_description;
     const auto init_windows = [&]( ui_adaptor & ui ) {
         w = catacurses::newwin( TERMY, TERMX, point_zero );
-        w_description = catacurses::newwin( 8, TERMX - iSecondColumn - 1,
+        w_description = catacurses::newwin( 30, TERMX - iSecondColumn - 1,
                                             point( iSecondColumn, 5 ) );
         ui.position_from_window( w );
     };
@@ -1119,12 +1119,12 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
         u.set_stored_kcal( u.get_healthy_kcal() );
         u.reset_bonuses(); // Removes pollution of stats by modifications appearing inside reset_stats(). Is reset_stats() even necessary in this context?
         switch( sel ) {
-            case 1:
+            case 1: {
                 mvwprintz( w, point( 2, 5 ), COL_SELECT, _( "Strength:" ) );
                 mvwprintz( w, point( 16, 5 ), c_light_gray, "%2d", u.str_max );
                 if( u.str_max >= HIGH_STAT ) {
                     mvwprintz( w, point( iSecondColumn, 3 ), c_light_red,
-                               _( "Increasing Str further costs 2 points" ) );
+                               _( "Increasing Strength further costs 2 points" ) );
                 }
                 u.recalc_hp();
                 u.set_stored_kcal( u.get_healthy_kcal() );
@@ -1133,18 +1133,63 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Carry weight: %.1f %s" ),
                            convert_weight( u.weight_capacity() ), weight_units() );
-                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Bash damage bonus: %.1f" ),
+                mvwprintz( w_description, point( 0, 2 ), COL_STAT_NEUTRAL,
+                           _( "Resistance to knock down effect when hit: %.1f" ), u.stability_roll() );
+                mvwprintz( w_description, point( 0, 3 ), COL_STAT_NEUTRAL, _( "Intimidation skill: %i" ),
+                           u.intimidation() );
+                mvwprintz( w_description, point( 0, 4 ), COL_STAT_NEUTRAL, _( "Maximum oxygen: %i" ),
+                           u.get_oxygen_max() );
+                mvwprintz( w_description, point( 0, 5 ), COL_STAT_NEUTRAL, _( "Shout volume: %i" ),
+                           u.get_shout_volume() );
+                mvwprintz( w_description, point( 0, 6 ), COL_STAT_NEUTRAL, _( "Lifting strength: %i" ),
+                           u.get_lift_str() );
+                mvwprintz( w_description, point( 0, 7 ), COL_STAT_NEUTRAL, _( "Move cost while swimming: %i" ),
+                           u.swim_speed() );
+                mvwprintz( w_description, point( 0, 8 ), COL_STAT_BONUS, _( "Bash damage bonus: %.1f" ),
                            u.bonus_damage( false ) );
-                fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Strength also makes you more resistant to many diseases and poisons, and makes actions which require brute force more effective." ) );
-                break;
+                mvwprintz( w_description, point( 0, 10 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
 
-            case 2:
+                int y = 11;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Throwing range, accuracy, and damage" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Reload speed for weapons using muscle power to reload: -20 moves per point of strength" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Pull strength of some mutations" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Resistance for being pulled or grabbed by some monsters" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed of corpses pulping" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed and effectiveness of prying things open, chopping wood, and mining" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of escaping grabs and traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Power produced by muscle-powered vehicles" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Most aspects of melee combat" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of smashing furniture or terrain" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Resistance to many diseases and poisons" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Ability to drag heavy objects and grants bonus to speed when dragging them" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Ability to wield heavy weapons with one hand" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Ability to manage gun recoil" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Duration of action of various drugs and alcohol" ) );
+            }
+            break;
+
+            case 2: {
                 mvwprintz( w, point( 2, 6 ), COL_SELECT, _( "Dexterity:" ) );
                 mvwprintz( w, point( 16, 6 ), c_light_gray, "%2d", u.dex_max );
                 if( u.dex_max >= HIGH_STAT ) {
                     mvwprintz( w, point( iSecondColumn, 3 ), c_light_red,
-                               _( "Increasing Dex further costs 2 points" ) );
+                               _( "Increasing Dexterity further costs 2 points" ) );
                 }
                 mvwprintz( w_description, point_zero, COL_STAT_BONUS, _( "Melee to-hit bonus: +%.2f" ),
                            u.get_melee_hit_base() );
@@ -1156,43 +1201,145 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                     mvwprintz( w_description, point( 0, 2 ), COL_STAT_PENALTY, _( "Ranged penalty: -%d" ),
                                std::abs( u.ranged_dex_mod() ) );
                 }
-                fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Dexterity also enhances many actions which require finesse." ) );
-                break;
+                mvwprintz( w_description, point( 0, 3 ), COL_STAT_NEUTRAL, _( "Dodge skill: %.f" ),
+                           u.get_dodge() );
+                mvwprintz( w_description, point( 0, 4 ), COL_STAT_NEUTRAL, _( "Move cost while swimming: %i" ),
+                           u.swim_speed() );
+                mvwprintz( w_description, point( 0, 6 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
+
+                int y = 7;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of lockpicking" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Resistance for being grabbed by some monsters" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of escaping grabs and traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of disarming traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of success when manipulating with gun modifications" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of repairing and modifying clothes and armor" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Attack speed and chance of critical hits in melee combat" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of stealing" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Throwing speed" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Aiming speed" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed and effectiveness of chopping wood with powered tools" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to avoid traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to get better results when butchering corpses or cutting items" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of avoiding cuts on sharp terrain" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of losing control of vehicle when driving" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of damaging melee weapon on attack" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Damage from falling" ) );
+            }
+            break;
 
             case 3: {
                 mvwprintz( w, point( 2, 7 ), COL_SELECT, _( "Intelligence:" ) );
                 mvwprintz( w, point( 16, 7 ), c_light_gray, "%2d", u.int_max );
                 if( u.int_max >= HIGH_STAT ) {
                     mvwprintz( w, point( iSecondColumn, 3 ), c_light_red,
-                               _( "Increasing Int further costs 2 points" ) );
+                               _( "Increasing Intelligence further costs 2 points" ) );
                 }
                 const int read_spd = u.read_speed();
                 mvwprintz( w_description, point_zero, ( read_spd == 100 ? COL_STAT_NEUTRAL :
                                                         ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ),
                            _( "Read times: %d%%" ), read_spd );
+                mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Persuade/lie skill: %i" ),
+                           u.persuade_skill() );
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Crafting bonus: %2d%%" ),
                            u.get_int() );
-                fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Intelligence is also used when crafting, installing bionics, and interacting with NPCs." ) );
+                mvwprintz( w_description, point( 0, 4 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
+
+                int y = 5;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed of 'catching up' practical experience to theoretical knowledge" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Detection and disarming traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of success when installing bionics" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of success when manipulating with gun modifications" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to learn a recipe when crafting from a book" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to learn martial arts techniques when using CQB bionic" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of hacking computers and card readers" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of successful robot reprogramming" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of successful decrypting memory cards" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of of bypassing vehicle security system" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to get better results when disassembling items" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of being paralyzed by fear attack" ) );
             }
             break;
 
-            case 4:
+            case 4: {
                 mvwprintz( w, point( 2, 8 ), COL_SELECT, _( "Perception:" ) );
                 mvwprintz( w, point( 16, 8 ), c_light_gray, "%2d", u.per_max );
                 if( u.per_max >= HIGH_STAT ) {
                     mvwprintz( w, point( iSecondColumn, 3 ), c_light_red,
-                               _( "Increasing Per further costs 2 points" ) );
+                               _( "Increasing Perception further costs 2 points" ) );
                 }
                 if( u.ranged_per_mod() > 0 ) {
                     mvwprintz( w_description, point_zero, COL_STAT_PENALTY, _( "Aiming penalty: -%d" ),
                                u.ranged_per_mod() );
                 }
-                fold_and_print( w_description, point( 0, 2 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Perception is also used for detecting traps and other things of interest." ) );
-                break;
+                mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Persuade/lie skill: %i" ),
+                           u.persuade_skill() );
+                mvwprintz( w_description, point( 0, 3 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
+
+                int y = 4;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed of 'catching up' practical experience to theoretical knowledge" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Time needed for safe cracking" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Sight distance on game map and overmap" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of stealing" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Throwing accuracy" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of losing control of vehicle when driving" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of spotting camouflaged creatures" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of lockpicking" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of foraging" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Precision when examining wounds and using first aid skill" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Detection and disarming traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Morale bonus when playing a musical instrument" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of repairing and modifying clothes and armor" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of critical hits in melee combat" ) );
+            }
+            break;
         }
 
         wnoutrefresh( w );


### PR DESCRIPTION
#### Summary
Interface "Detailed information for stats on character creation menu"

#### Purpose of change
More info allows less experienced players to meaningfully choose stats when creating their characters.

#### Describe the solution
Looked through the code, checked for `get_str`, `dex_cur`, `EFFECT_INT` and similar and added relevant information to character creation menu.

#### Describe alternatives you've considered
None.

#### Testing
Started creating character, switched to STATS tab, looked on the screen.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/235296574-06a94632-8d40-45ba-8a5e-2b5c89b38a92.png)

![изображение](https://user-images.githubusercontent.com/11132525/235296580-6b46fa61-00ef-41c6-bd75-d512a3edbfd5.png)

![изображение](https://user-images.githubusercontent.com/11132525/235296585-8a583074-ced2-4ffd-b541-515fed7ff3b6.png)

![изображение](https://user-images.githubusercontent.com/11132525/235296588-7b773d6e-0859-436c-b19c-e2dff0465a27.png)
