### PR TITLE
Added a NPC chat command that orders NPC to move to location player-chosen location

### DIFF
--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -11,6 +11,7 @@ Player character won't fail at crafting items from very fast (time to craft <=10
 Characters with Infection Immune trait no longer need to sterilize bionics prior to installation
 Prompt player to hold his breath upon entering tiles with a smoke
 Player character now will get sick with common cold or flu only after contacts with NPCs or ferals
+Player now can order friendly NPCs to move to player-chosen location
 
 ## Content
 Returned back previously obsoleted SPIW weapons

--- a/src/npc.h
+++ b/src/npc.h
@@ -1292,6 +1292,8 @@ class npc : public Character
 
         // Where we last saw the player
         std::optional<tripoint_abs_ms> last_player_seen_pos;
+        // Player orders a friendly NPC to move to this position
+        std::optional<tripoint_abs_ms> goto_to_this_pos;
         int last_seen_player_turn = 0; // Timeout to forgetting
         tripoint wanted_item_pos; // The square containing an item we want
         // These are the coordinates that a guard will return to inside of their goal tripoint

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -162,6 +162,7 @@ enum npc_action : int {
     npc_flee, npc_melee, npc_shoot,
     npc_look_for_player, npc_heal_player, npc_follow_player, npc_follow_embarked,
     npc_talk_to_player, npc_mug_player,
+    npc_goto_to_this_pos,
     npc_goto_destination,
     npc_avoid_friendly_fire,
     npc_escape_explosion,
@@ -925,6 +926,10 @@ void npc::move()
         }
     }
 
+    if( action == npc_undecided && is_walking_with() && goto_to_this_pos ) {
+        action = npc_goto_to_this_pos;
+    }
+
     // check if in vehicle before doing any other follow activities
     if( action == npc_undecided && is_walking_with() && player_character.in_vehicle &&
         !in_vehicle ) {
@@ -1374,6 +1379,16 @@ void npc::execute_action( npc_action action )
         case npc_mug_player:
             mug_player( player_character );
             break;
+
+        case npc_goto_to_this_pos: {
+            update_path( get_map().getlocal( *goto_to_this_pos ) );
+            move_to_next();
+
+            if( get_location() == *goto_to_this_pos ) {
+                goto_to_this_pos = std::nullopt;
+            }
+            break;
+        }
 
         case npc_goto_destination:
             go_to_omt_destination();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4303,6 +4303,8 @@ std::string npc_action_name( npc_action action )
             return "Do nothing";
         case npc_do_attack:
             return "Attack";
+        case npc_goto_to_this_pos:
+            return "Go to position";
         case num_npc_actions:
             return "Unnamed action";
     }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "achievement.h"
+#include "action.h"
 #include "activity_type.h"
 #include "auto_pickup.h"
 #include "avatar.h"
@@ -310,6 +311,7 @@ enum npc_chat_menu {
     NPC_CHAT_SENTENCE,
     NPC_CHAT_GUARD,
     NPC_CHAT_FOLLOW,
+    NPC_CHAT_MOVE_TO_POS,
     NPC_CHAT_AWAKE,
     NPC_CHAT_MOUNT,
     NPC_CHAT_DISMOUNT,
@@ -672,6 +674,9 @@ void game::chat()
                         string_format( _( "Tell %s to guard" ), followers.front()->get_name() ) :
                         _( "Tell someone to guard…" )
                       );
+        nmenu.addentry( NPC_CHAT_MOVE_TO_POS, true, 'G',
+                        follower_count == 1 ? string_format( _( "Tell %s to move to location" ),
+                                followers.front()->get_name() ) : _( "Tell someone to move to location…" ) );
         nmenu.addentry( NPC_CHAT_AWAKE, true, 'w', _( "Tell everyone on your team to wake up" ) );
         nmenu.addentry( NPC_CHAT_MOUNT, true, 'M', _( "Tell everyone on your team to mount up" ) );
         nmenu.addentry( NPC_CHAT_DISMOUNT, true, 'm', _( "Tell everyone on your team to dismount" ) );
@@ -772,6 +777,35 @@ void game::chat()
             } else {
                 talk_function::assign_guard( *followers[npcselect] );
                 yell_msg = string_format( _( "Guard here, %s!" ), followers[npcselect]->get_name() );
+            }
+            break;
+        }
+        case NPC_CHAT_MOVE_TO_POS: {
+            const int npcselect = npc_select_menu( followers, _( "Who should move?" ) );
+            if( npcselect < 0 ) {
+                return;
+            }
+
+            map &here = get_map();
+            std::optional<tripoint> p = look_around();
+
+            if( !p ) {
+                return;
+            }
+
+            if( here.impassable( tripoint( *p ) ) ) {
+                add_msg( m_info, _( "This destination can't be reached." ) );
+                return;
+            }
+
+            if( npcselect == follower_count ) {
+                for( npc *them : followers ) {
+                    them->goto_to_this_pos = here.getglobal( *p );
+                }
+                yell_msg = _( "Everyone move there!" );
+            } else {
+                followers[npcselect]->goto_to_this_pos = here.getglobal( *p );
+                yell_msg = string_format( _( "Move there, %s!" ), followers[npcselect]->get_name() );
             }
             break;
         }


### PR DESCRIPTION
#### Summary
Features "Added a NPC chat command that orders NPC to move to location player-chosen location"

#### Purpose of change
More control over NPC followers.

#### Describe the solution
- Added command to move NPC to player-chosen location. 
- This works only if NPC is following the player. NPCs on guard are not available for this command. 
- After NPC reaches said location, he returns to his old duties (returns to player).
- Works both for single NPC and several NPCs. 
- NPCs won't go into impassable locations.

#### Describe alternatives you've considered
None.

#### Testing
Got two friendly NPCs, made them go to location, both single and in group.

#### Additional context
![345](https://user-images.githubusercontent.com/11132525/235664173-85bf5f8b-522b-4989-9ba9-24596fda17ef.gif)

![567](https://user-images.githubusercontent.com/11132525/235665168-c0c7c16e-2116-48e2-87c8-a4662b71d720.gif)