### PR TITLE
Activate trap on force-moved enemies

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11288,6 +11288,8 @@ void Character::knock_back_to( const tripoint &to )
 
     } else { // It's no wall
         setpos( to );
+
+        here.creature_on_trap( *this );
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4592,12 +4592,15 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
     // perhaps that is what it should do?
     tripoint tp = traj.front();
     creature_tracker &creatures = get_creature_tracker();
+    map &here = get_map();
     if( !creatures.creature_at( tp ) ) {
         debugmsg( _( "Nothing at (%d,%d,%d) to knockback!" ), tp.x, tp.y, tp.z );
         return;
     }
     std::size_t force_remaining = traj.size();
     if( monster *const targ = creatures.creature_at<monster>( tp, true ) ) {
+        tripoint start_pos = targ->pos();
+
         if( stun > 0 ) {
             targ->add_effect( effect_stunned, 1_turns * stun );
             add_msg( _( "%s was stunned!" ), targ->name() );
@@ -4655,8 +4658,13 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                     add_msg( _( "The %s flops around and dies!" ), targ->name() );
                 }
             }
+
+            if( start_pos != targ->pos() ) {
+                here.creature_on_trap( *targ );
+            }
         }
     } else if( npc *const targ = creatures.creature_at<npc>( tp ) ) {
+        tripoint start_pos = targ->pos();
         if( stun > 0 ) {
             targ->add_effect( effect_stunned, 1_turns * stun );
             add_msg( _( "%s was stunned!" ), targ->get_name() );
@@ -4718,8 +4726,13 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                 break;
             }
             targ->setpos( traj[i] );
+
+            if( start_pos != targ->pos() ) {
+                here.creature_on_trap( *targ );
+            }
         }
     } else if( u.pos() == tp ) {
+        tripoint start_pos = u.pos();
         if( stun > 0 ) {
             u.add_effect( effect_stunned, 1_turns * stun );
             add_msg( m_bad, n_gettext( "You were stunned for %d turn!",
@@ -4795,6 +4808,10 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                 avatar_action::swim( m, u, u.pos() );
             } else {
                 u.setpos( traj[i] );
+            }
+
+            if( start_pos != u.pos() ) {
+                here.creature_on_trap( u );
             }
         }
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2119,6 +2119,8 @@ void monster::knock_back_to( const tripoint &to )
 
     } else { // It's no wall
         setpos( to );
+
+        here.creature_on_trap( *this );
     }
     check_dead_state();
 }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -142,9 +142,10 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
                 g->update_map( *p );
             }
             critter.remove_effect( effect_grabbed );
+            here.creature_on_trap( critter );
             return true;
         }
-        //Character *const poor_player = dynamic_cast<Character *>( poor_soul );
+
         if( force ) {
             poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), 9999 );
             poor_soul->check_dead_state();


### PR DESCRIPTION
#### Summary
Bugfixes "Activate trap on force-moved enemies"

#### Purpose of change

#### Describe the solution
Ported https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2696 by @MrLostman.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->