### PR TITLE
Allow conversation with monsters and show NPC location when chatting

### DIFF
--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1037,6 +1037,7 @@ Other monster flags.
 - ```ACIDTRAIL``` Leaves a trail of acid.
 - ```ACID_BLOOD``` Makes monster bleed acid. Does not automatically dissolve in a pool of acid on death.
 - ```ALL_SEEING``` Can see every creature within its vision (highest of day/night vision counts) on the same Z-level.
+- ```ALWAYS_SEES_YOU``` This monster always knows where the avatar is
 - ```ALWAYS_VISIBLE``` This monster can always be seen regardless of line of sight or light level.
 - ```ANIMAL``` Is an _animal_ for purposes of the `Animal Empathy` trait.
 - ```AQUATIC``` Confined to water.
@@ -1054,6 +1055,8 @@ Other monster flags.
 - ```CANPLAY``` This creature can be played with if it's a pet.
 - ```CLIMBS``` Can climb over fences or similar obstacles quickly.
 - ```COLDPROOF``` Immune to cold damage.
+- ```CONVERSATION``` This monster can engage in conversation.  Will need to have chat_topics as well.
+- ```DEADLY_VIRUS``` This monster can inflict the zombie_virus effect
 - ```DESTROYS``` Bashes down walls and more. (2.5x bash multiplier, where base is the critter's max melee bashing)
 - ```DIGS``` Digs through the ground. Will not travel through non-diggable terrain such as roads.
 - ```DOGFOOD``` Can be ordered to attack with a dog whistle.
@@ -1089,6 +1092,7 @@ Other monster flags.
 - ```MILITARY_MECH``` Is a military-grade mech.
 - ```MILKABLE``` Produces milk when milked.
 - ```NEMESIS``` Tags Nemesis enemies for the HAS_NEMESIS mutation.
+- ```NEVER_WANDER``` This monster will never join wandering hordes.
 - ```NIGHT_INVISIBILITY``` Monster becomes invisible if it's more than one tile away and the lighting on its tile is LL_LOW or less. Visibility is not affected by night vision.
 - ```NOT_HALLUCINATION``` This monster does not appear while the player is hallucinating.
 - ```NOGIB``` Does not leave gibs / meat chunks when killed with huge damage.
@@ -1131,6 +1135,7 @@ Other monster flags.
 - ```SUNDEATH``` Dies in full sunlight.
 - ```SWARMS``` Groups together and forms loose packs.
 - ```SWIMS``` Treats water as 50 movement point terrain.
+- ```VAMP_VIRUS``` This monster can inflict the vampire_virus effect
 - ```VENOM``` Attack may poison the player.
 - ```VERMIN``` Obsolete flag for inconsequential monsters, now prevents loading.
 - ```WARM``` Warm blooded.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5850,6 +5850,8 @@ void game::examine( const tripoint &examp, bool with_pickup )
                 if( monexamine::mfriend_menu( *mon ) ) {
                     return;
                 }
+            } else if( mon->has_flag( MF_CONVERSATION ) && !mon->type->chat_topics.empty() ) {
+                get_avatar().talk_to( get_talker_for( mon ) );
             }
         } else if( u.is_mounted() ) {
             add_msg( m_warning, _( "You cannot do that while mounted." ) );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -910,7 +910,8 @@ bool monexamine::mfriend_menu( monster &z )
         swap_pos = 0,
         push_monster,
         rename,
-        attack
+        attack,
+        talk_to
     };
 
     uilist amenu;
@@ -922,6 +923,9 @@ bool monexamine::mfriend_menu( monster &z )
     amenu.addentry( push_monster, true, 'p', _( "Push %s" ), pet_name );
     amenu.addentry( rename, true, 'e', _( "Rename" ) );
     amenu.addentry( attack, true, 'a', _( "Attack" ) );
+    if( !z.type->chat_topics.empty() ) {
+        amenu.addentry( talk_to, true, 'c', _( "Talk to %s" ), pet_name );
+    }
 
     amenu.query();
     const int choice = amenu.ret;
@@ -940,6 +944,9 @@ bool monexamine::mfriend_menu( monster &z )
             if( query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
                 get_player_character().melee_attack( z, true );
             }
+            break;
+        case talk_to:
+            get_avatar().talk_to( get_talker_for( z ) );
             break;
         default:
             break;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -202,6 +202,7 @@ std::string enum_to_string<m_flag>( m_flag data )
         case MF_ALWAYS_SEES_YOU: return "ALWAYS_SEES_YOU";
         case MF_ALL_SEEING: return "ALL_SEEING";
         case MF_NEVER_WANDER: return "NEVER_WANDER";
+        case MF_CONVERSATION: return "CONVERSATION";
         // *INDENT-ON*
         case m_flag::MF_MAX:
             break;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -175,6 +175,7 @@ enum m_flag : int {
     MF_ALWAYS_SEES_YOU,     // This monster always knows where the avatar is
     MF_ALL_SEEING,          // This monster can see everything within its vision range regardless of light or obstacles
     MF_NEVER_WANDER,        // This monster will never join wandering hordes.
+    MF_CONVERSATION,        // This monster can engage in conversation.  Will need to have chat_topics as well.
     MF_MAX                  // Sets the length of the flags - obviously must be LAST
 };
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -344,17 +344,57 @@ static int npc_select_menu( const std::vector<npc *> &npc_list, const std::strin
         return 0;
     } else {
         uilist nmenu;
+        std::vector<tripoint> locations;
         nmenu.text = prompt;
         for( const npc *elem : npc_list ) {
             nmenu.addentry( -1, true, MENU_AUTOASSIGN, elem->name_and_activity() );
+            locations.emplace_back( elem->pos_bub().raw() );
         }
         if( npc_count > 1 && everyone ) {
             nmenu.addentry( -1, true, MENU_AUTOASSIGN, _( "Everyone" ) );
+            locations.emplace_back( get_avatar().pos_bub().raw() );
         }
+        pointmenu_cb callback( locations );
+        nmenu.callback = &callback;
+        nmenu.w_y_setup = 0;
         nmenu.query();
         return nmenu.ret;
     }
 
+}
+
+static int creature_select_menu( const std::vector<Creature *> &talker_list,
+                                 const std::string &prompt,
+                                 const bool everyone = true )
+{
+    if( talker_list.empty() ) {
+        return -1;
+    }
+    const int npc_count = talker_list.size();
+    if( npc_count == 1 ) {
+        return 0;
+    } else {
+        uilist nmenu;
+        std::vector<tripoint> locations;
+        nmenu.text = prompt;
+        for( const Creature *elem : talker_list ) {
+            if( elem->is_npc() ) {
+                nmenu.addentry( -1, true, MENU_AUTOASSIGN, elem->as_npc()->name_and_activity() );
+            } else {
+                nmenu.addentry( -1, true, MENU_AUTOASSIGN, elem->disp_name() );
+            }
+            locations.emplace_back( elem->pos_bub().raw() );
+        }
+        if( npc_count > 1 && everyone ) {
+            nmenu.addentry( -1, true, MENU_AUTOASSIGN, _( "Everyone" ) );
+            locations.emplace_back( get_avatar().pos_bub().raw() );
+        }
+        pointmenu_cb callback( locations );
+        nmenu.callback = &callback;
+        nmenu.w_y_setup = 0;
+        nmenu.query();
+        return nmenu.ret;
+    }
 }
 
 std::vector<int> npcs_select_menu( const std::vector<Character *> &npc_list,
@@ -580,9 +620,10 @@ void game::chat()
     Character &player_character = get_player_character();
     int volume = player_character.get_shout_volume();
 
-    const std::vector<npc *> available = get_npcs_if( [&]( const npc & guy ) {
+    const std::vector<Creature *> available = get_creatures_if( [&]( const Creature & guy ) {
         // TODO: Get rid of the z-level check when z-level vision gets "better"
-        return u.posz() == guy.posz() && u.sees( guy.pos() ) &&
+        return ( guy.is_npc() || ( guy.is_monster() && guy.as_monster()->has_flag( MF_CONVERSATION ) &&
+                                   !guy.as_monster()->type->chat_topics.empty() ) ) && u.posz() == guy.posz() && u.sees( guy.pos() ) &&
                rl_dist( u.pos(), guy.pos() ) <= SEEX * 2;
     } );
     const int available_count = available.size();
@@ -634,11 +675,16 @@ void game::chat()
     nmenu.text = std::string( _( "What do you want to do?" ) );
 
     if( !available.empty() ) {
-        const npc *guy = available.front();
+        const Creature *guy = available.front();
+        std::string title;
+        if( guy->is_npc() ) {
+            title = guy->as_npc()->name_and_activity();
+        } else if( guy->is_monster() ) {
+            title = guy->as_monster()->disp_name();
+        }
         nmenu.addentry( NPC_CHAT_TALK, true, 't', available_count == 1 ?
-                        string_format( _( "Talk to %s" ), guy->name_and_activity() ) :
-                        _( "Talk to…" )
-                      );
+                        string_format( _( "Talk to %s" ), title ) :
+                        _( "Talk to…" ) );
     }
     nmenu.addentry( NPC_CHAT_YELL, true, 'a', _( "Yell" ) );
     nmenu.addentry( NPC_CHAT_SENTENCE, true, 'b', _( "Yell a sentence" ) );
@@ -698,7 +744,7 @@ void game::chat()
 
     switch( nmenu.ret ) {
         case NPC_CHAT_TALK: {
-            const int npcselect = npc_select_menu( available, _( "Talk to whom?" ), false );
+            const int npcselect = creature_select_menu( available, _( "Talk to whom?" ), false );
             if( npcselect < 0 ) {
                 return;
             }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -980,14 +980,14 @@ uilist::handle_mouse_result_t uilist::handle_mouse( const input_context &ctxt,
                     // function is called again.
                     fselected = new_fselected;
                     selected = fentries[fselected];
+                    if( callback != nullptr ) {
+                        callback->select( this );
+                    }
                     if( ret_act == "SELECT" ) {
                         if( enabled || allow_disabled ) {
                             ret = entries[selected].retval;
                             // Treating clicking during filtering as confirmation and stop filtering
                             result = handle_mouse_result_t::confirmed;
-                        }
-                        if( callback != nullptr ) {
-                            callback->select( this );
                         }
                     }
                 }


### PR DESCRIPTION
#### Summary
Features "Allow conversation with monsters and show NPC location when chatting"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Ported https://github.com/CleverRaven/Cataclysm-DDA/pull/64928 by @Ramza13. Ported https://github.com/CleverRaven/Cataclysm-DDA/pull/65432 by @Qrox.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->