### PR TITLE
Larger and reorganized player info menu

### DIFF
--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -28,7 +28,7 @@ Show gender on NPC
 Added possibility to show or hide several non-player-related messages in the log
 Much more detailed info for player stats in new character creation menu
 Larger and more I18n-friendly safemode UI
-Larger and reorganized player info menu (@ by default) to take advantage of modern displays with high resolutions
+Larger, reorganized player info menu with customizable columns width
 
 ## Balance
 Increased limit of dragging vehicles from 1000 kg to 5000 kg

--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -26,7 +26,9 @@ Added possibility to show or hide source of content when examining an item
 Added possibility to change color for 'Explored' tiles through json editing
 Show gender on NPC
 Added possibility to show or hide several non-player-related messages in the log
+Much more detailed info for player stats in new character creation menu
 Larger and more I18n-friendly safemode UI
+Larger and reorganized player info menu (@ by default) to take advantage of modern displays with high resolutions
 
 ## Balance
 Increased limit of dragging vehicles from 1000 kg to 5000 kg

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4186,6 +4186,55 @@
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
+    "id": "SELECT_STATS_TAB",
+    "name": "Select stats tab",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "PLAYER_INFO",
+    "id": "SELECT_ENCUMBRANCE_TAB",
+    "name": "Select encumbrance tab",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "PLAYER_INFO",
+    "id": "SELECT_SKILLS_TAB",
+    "name": "Select skills tab",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "PLAYER_INFO",
+    "id": "SELECT_TRAITS_TAB",
+    "name": "Select traits tab",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F4" } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "PLAYER_INFO",
+    "id": "SELECT_BIONICS_TAB",
+    "name": "Select bionics tab",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F5" } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "PLAYER_INFO",
+    "id": "SELECT_EFFECTS_TAB",
+    "name": "Select effects tab",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F6" } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "PLAYER_INFO",
+    "id": "SELECT_PROFICIENCIES_TAB",
+    "name": "Select proficiencies tab",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F7" } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "PLAYER_INFO",
     "id": "VIEW_PROFICIENCIES",
     "name": "View character proficiencies",
     "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1735,6 +1735,13 @@ void options_manager::add_options_interface()
 
     add_empty_line();
 
+    add( "COLUMN_WIDTH", "interface", to_translation( "Width of columns in player info menu" ),
+         to_translation( "Sets width of columns in player info menu." ),
+         26, 50, 26
+       );
+
+    add_empty_line();
+
     add_option_group( "interface", Group( "additional_messages_in_log",
                                           to_translation( "Additional messages in the log" ),
                                           to_translation( "If true, some additional messages will be shown in the message log." ) ),

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1552,12 +1552,10 @@ void Character::disp_info( bool customize_character )
         }
         skillslist.emplace_back( s, false );
     }
-    const unsigned int skill_win_size_y_max = 1 + skillslist.size();
-    const unsigned int info_win_size_y = 6;
 
+    const unsigned int info_win_size_y = 6;
     const unsigned int grid_height = 10;
     const unsigned int encumbrance_height = 11;
-
     const unsigned int infooffsetybottom = 3 + info_win_size_y;
 
     // Print name and header

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1552,7 +1552,7 @@ void Character::disp_info( bool customize_character )
         skillslist.emplace_back( s, false );
     }
 
-    const unsigned int skill_win_size_y_max = 1 + skillslist.size();
+    const unsigned int skill_win_size_y_max = 2 + skillslist.size();
     const unsigned int info_win_size_y = 6;
     const unsigned int grid_height = 10;
     const unsigned int encumbrance_height = 11;
@@ -1734,12 +1734,12 @@ void Character::disp_info( bool customize_character )
             skill_win_size_y = maxy - infooffsetybottom;
         }
 
-        w_skills = catacurses::newwin( skill_win_size_y, grid_width,
+        w_skills = catacurses::newwin( skill_win_size_y - 1, grid_width,
                                        point( grid_width + 1, infooffsetybottom ) );
-        w_skills_border = catacurses::newwin( skill_win_size_y + 2, grid_width + 2,
+        w_skills_border = catacurses::newwin( skill_win_size_y + 1, grid_width + 2,
                                               point( grid_width, infooffsetybottom - 1 ) );
         border_skills.set( point( grid_width, infooffsetybottom - 1 ),
-                           point( grid_width + 2, skill_win_size_y + 2 ) );
+                           point( grid_width + 2, skill_win_size_y + 1 ) );
         ui_skills.position_from_window( w_skills_border );
     } );
     ui_skills.mark_resize();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1512,7 +1512,7 @@ void Character::disp_info( bool customize_character )
     } ), effect_name_and_text.end() );
 
     const unsigned int effect_win_size_y_max = 1 + effect_name_and_text.size();
-    const unsigned int proficiency_win_size_y_max = 1 + display_proficiencies().size();
+    const unsigned int proficiency_win_size_y_max = 2 + display_proficiencies().size();
 
     std::vector<trait_and_var> traitslist = get_mutations_variants( false );
     std::sort( traitslist.begin(), traitslist.end(), trait_display_sort );
@@ -1553,6 +1553,7 @@ void Character::disp_info( bool customize_character )
         skillslist.emplace_back( s, false );
     }
 
+    const unsigned int skill_win_size_y_max = 1 + skillslist.size();
     const unsigned int info_win_size_y = 6;
     const unsigned int grid_height = 10;
     const unsigned int encumbrance_height = 11;
@@ -1718,17 +1719,24 @@ void Character::disp_info( bool customize_character )
     } );
 
     // SKILLS
+    unsigned int skill_win_size_y = 0;
     catacurses::window w_skills;
     catacurses::window w_skills_border;
     border_helper::border_info &border_skills = borders.add_border();
     ui_adaptor ui_skills;
     ui_skills.on_screen_resize( [&]( ui_adaptor & ui_skills ) {
-        w_skills = catacurses::newwin( TERMY - infooffsetybottom - 1, grid_width,
+        const unsigned int maxy = static_cast<unsigned>( TERMY );
+        skill_win_size_y = skill_win_size_y_max;
+        if( skill_win_size_y + infooffsetybottom > maxy ) {
+            skill_win_size_y = maxy - infooffsetybottom;
+        }
+
+        w_skills = catacurses::newwin( skill_win_size_y, grid_width,
                                        point( grid_width + 1, infooffsetybottom ) );
-        w_skills_border = catacurses::newwin( TERMY - infooffsetybottom + 1, grid_width + 2,
+        w_skills_border = catacurses::newwin( skill_win_size_y + 2, grid_width + 2,
                                               point( grid_width, infooffsetybottom - 1 ) );
         border_skills.set( point( grid_width, infooffsetybottom - 1 ),
-                           point( grid_width + 2, TERMY - infooffsetybottom + 1 ) );
+                           point( grid_width + 2, skill_win_size_y + 2 ) );
         ui_skills.position_from_window( w_skills_border );
     } );
     ui_skills.mark_resize();
@@ -1825,12 +1833,12 @@ void Character::disp_info( bool customize_character )
     ui_proficiencies.on_screen_resize( [&]( ui_adaptor & ui_proficiencies ) {
         std::tie( effect_win_size_y, proficiency_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, effect_win_size_y_max, proficiency_win_size_y_max );
-        w_proficiencies = catacurses::newwin( proficiency_win_size_y, grid_width,
+        w_proficiencies = catacurses::newwin( proficiency_win_size_y - 1, grid_width,
                                               point( grid_width * 3 + 3, infooffsetybottom + effect_win_size_y + 1 ) );
-        w_proficiencies_border = catacurses::newwin( proficiency_win_size_y + 2, grid_width + 2,
+        w_proficiencies_border = catacurses::newwin( proficiency_win_size_y + 1, grid_width + 2,
                                  point( grid_width * 3 + 2, infooffsetybottom + effect_win_size_y ) );
         border_proficiencies.set( point( grid_width * 3 + 2, infooffsetybottom + effect_win_size_y ),
-                                  point( grid_width + 2, proficiency_win_size_y + 2 ) );
+                                  point( grid_width + 2, proficiency_win_size_y + 1 ) );
         ui_proficiencies.position_from_window( w_proficiencies_border );
     } );
     ui_proficiencies.mark_resize();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -317,6 +317,8 @@ static void draw_proficiencies_tab( ui_adaptor &ui, const catacurses::window &wi
     }
     center_print( win, 0, title_color, string_format( "[<color_yellow>%s</color>] %s",
                   ctxt.get_desc( "VIEW_PROFICIENCIES" ), _( title_PROFICIENCIES ) ) );
+    right_print( win, 0, 0, title_color, string_format( "[<color_yellow>%s</color>]",
+                 ctxt.get_desc( "SELECT_PROFICIENCIES_TAB" ) ) );
 
     const int height = getmaxy( win ) - 1;
     const bool do_draw_scrollbar = height < static_cast<int>( profs.size() );
@@ -386,6 +388,8 @@ static void draw_stats_tab( ui_adaptor &ui, const catacurses::window &w_stats, c
     center_print( w_stats, 0, title_col,
                   string_format( "[<color_yellow>%s</color>] %s",
                                  ctxt.get_desc( "VIEW_BODYSTAT" ), _( title_STATS ) ) );
+    right_print( w_stats, 0, 0, title_col, string_format( "[<color_yellow>%s</color>]",
+                 ctxt.get_desc( "SELECT_STATS_TAB" ) ) );
 
     const auto highlight_line = [is_current_tab, line]( const unsigned line_to_draw ) {
         return is_current_tab && line == line_to_draw;
@@ -554,12 +558,14 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
 
 static void draw_encumbrance_tab( ui_adaptor &ui, const catacurses::window &w_encumb,
                                   const Character &you, const unsigned line,
-                                  const player_display_tab curtab )
+                                  const player_display_tab curtab, const input_context &ctxt )
 {
     werase( w_encumb );
     const bool is_current_tab = curtab == player_display_tab::encumbrance;
     const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
     center_print( w_encumb, 0, title_col, _( title_ENCUMB ) );
+    right_print( w_encumb, 0, 0, title_col, string_format( "[<color_yellow>%s</color>]",
+                 ctxt.get_desc( "SELECT_ENCUMBRANCE_TAB" ) ) );
     if( is_current_tab ) {
         ui.set_cursor( w_encumb, point_zero );
         you.print_encumbrance( ui, w_encumb, line );
@@ -596,7 +602,7 @@ static void draw_encumbrance_info( const catacurses::window &w_info, const Chara
 
 static void draw_traits_tab( ui_adaptor &ui, const catacurses::window &w_traits,
                              const unsigned line, const player_display_tab curtab,
-                             const std::vector<trait_and_var> &traitslist )
+                             const std::vector<trait_and_var> &traitslist, const input_context &ctxt )
 {
     werase( w_traits );
     const bool is_current_tab = curtab == player_display_tab::traits;
@@ -605,6 +611,8 @@ static void draw_traits_tab( ui_adaptor &ui, const catacurses::window &w_traits,
         ui.set_cursor( w_traits, point_zero );
     }
     center_print( w_traits, 0, title_col, _( title_TRAITS ) );
+    right_print( w_traits, 0, 0, title_col, string_format( "[<color_yellow>%s</color>]",
+                 ctxt.get_desc( "SELECT_TRAITS_TAB" ) ) );
 
     const int height = getmaxy( w_traits ) - 1;
     const bool do_draw_scrollbar = height < static_cast<int>( traitslist.size() );
@@ -652,12 +660,14 @@ struct bionic_grouping {
 static void draw_bionics_tab( ui_adaptor &ui, const catacurses::window &w_bionics,
                               const Character &you, const unsigned line,
                               const player_display_tab curtab,
-                              const std::vector<bionic_grouping> &bionicslist )
+                              const std::vector<bionic_grouping> &bionicslist, const input_context &ctxt )
 {
     werase( w_bionics );
     const bool is_current_tab = curtab == player_display_tab::bionics;
     const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
     center_print( w_bionics, 0, title_col, _( title_BIONICS ) );
+    right_print( w_bionics, 0, 0, title_col, string_format( "[<color_yellow>%s</color>]",
+                 ctxt.get_desc( "SELECT_BIONICS_TAB" ) ) );
     int power_amount;
     std::string power_unit;
     if( you.get_power_level() < 1_J ) {
@@ -724,7 +734,8 @@ static void draw_bionics_info( const catacurses::window &w_info, const unsigned 
 
 static void draw_effects_tab( ui_adaptor &ui, const catacurses::window &w_effects,
                               const unsigned line, const player_display_tab curtab,
-                              const std::vector<std::pair<std::string, std::string>> &effect_name_and_text )
+                              const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
+                              const input_context &ctxt )
 {
     werase( w_effects );
     const bool is_current_tab = curtab == player_display_tab::effects;
@@ -733,6 +744,8 @@ static void draw_effects_tab( ui_adaptor &ui, const catacurses::window &w_effect
         ui.set_cursor( w_effects, point_zero );
     }
     center_print( w_effects, 0, title_col, _( title_EFFECTS ) );
+    right_print( w_effects, 0, 0, title_col, string_format( "[<color_yellow>%s</color>]",
+                 ctxt.get_desc( "SELECT_EFFECTS_TAB" ) ) );
 
     const int height = getmaxy( w_effects ) - 1;
     const bool do_draw_scrollbar = height < static_cast<int>( effect_name_and_text.size() );
@@ -779,7 +792,7 @@ struct HeaderSkill {
 static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                              Character &you, unsigned int line, const player_display_tab curtab,
                              std::vector<HeaderSkill> &skillslist,
-                             const size_t skill_win_size_y )
+                             const size_t skill_win_size_y, const input_context &ctxt )
 {
     unsigned int grid_width = get_option<int>( "COLUMN_WIDTH" );
     const int col_width = getmaxx( w_skills ) - 1;
@@ -791,6 +804,8 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
         ui.set_cursor( w_skills, point_zero );
     }
     center_print( w_skills, 0, cstatus, _( title_SKILLS ) );
+    right_print( w_skills, 0, 0, c_light_gray, string_format( "[<color_yellow>%s</color>]",
+                 ctxt.get_desc( "SELECT_SKILLS_TAB" ) ) );
 
     size_t min = 0;
     size_t max = 0;
@@ -1378,6 +1393,55 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         if( you.is_avatar() ) {
             you.as_avatar()->disp_medical();
         }
+    } else if( action == "SELECT_STATS_TAB" ) {
+        invalidate_tab( curtab );
+        curtab = player_display_tab::stats;
+        invalidate_tab( curtab );
+        line = 0;
+        info_line = 0;
+        ui_info.invalidate_ui();
+    } else if( action == "SELECT_ENCUMBRANCE_TAB" ) {
+        invalidate_tab( curtab );
+        curtab = player_display_tab::encumbrance;
+        invalidate_tab( curtab );
+        line = 0;
+        info_line = 0;
+        ui_info.invalidate_ui();
+    } else if( action == "SELECT_SKILLS_TAB" ) {
+        invalidate_tab( curtab );
+        curtab = player_display_tab::skills;
+        invalidate_tab( curtab );
+        line = 1; // avoid a call to skip_skill_headers
+        info_line = 0;
+        ui_info.invalidate_ui();
+    } else if( action == "SELECT_TRAITS_TAB" ) {
+        invalidate_tab( curtab );
+        curtab = player_display_tab::traits;
+        invalidate_tab( curtab );
+        line = 0;
+        info_line = 0;
+        ui_info.invalidate_ui();
+    } else if( action == "SELECT_BIONICS_TAB" ) {
+        invalidate_tab( curtab );
+        curtab = player_display_tab::bionics;
+        invalidate_tab( curtab );
+        line = 0;
+        info_line = 0;
+        ui_info.invalidate_ui();
+    } else if( action == "SELECT_EFFECTS_TAB" ) {
+        invalidate_tab( curtab );
+        curtab = player_display_tab::effects;
+        invalidate_tab( curtab );
+        line = 0;
+        info_line = 0;
+        ui_info.invalidate_ui();
+    } else if( action == "SELECT_PROFICIENCIES_TAB" ) {
+        invalidate_tab( curtab );
+        curtab = player_display_tab::proficiencies;
+        invalidate_tab( curtab );
+        line = 0;
+        info_line = 0;
+        ui_info.invalidate_ui();
     }
     return done;
 }
@@ -1592,6 +1656,13 @@ void Character::disp_info( bool customize_character )
     ctxt.register_action( "SELECT_TRAIT_VARIANT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "MEDICAL_MENU" );
+    ctxt.register_action( "SELECT_STATS_TAB" );
+    ctxt.register_action( "SELECT_ENCUMBRANCE_TAB" );
+    ctxt.register_action( "SELECT_SKILLS_TAB" );
+    ctxt.register_action( "SELECT_TRAITS_TAB" );
+    ctxt.register_action( "SELECT_BIONICS_TAB" );
+    ctxt.register_action( "SELECT_EFFECTS_TAB" );
+    ctxt.register_action( "SELECT_PROFICIENCIES_TAB" );
 
     std::map<std::string, int> speed_effects;
     for( auto &elem : *effects ) {
@@ -1695,7 +1766,7 @@ void Character::disp_info( bool customize_character )
         borders.draw_border( w_encumb_border );
         wnoutrefresh( w_encumb_border );
         ui_encumb.disable_cursor();
-        draw_encumbrance_tab( ui_encumb, w_encumb, *this, line, curtab );
+        draw_encumbrance_tab( ui_encumb, w_encumb, *this, line, curtab, ctxt );
     } );
 
     // SPEED
@@ -1747,7 +1818,7 @@ void Character::disp_info( bool customize_character )
         borders.draw_border( w_skills_border );
         wnoutrefresh( w_skills_border );
         ui_skills.disable_cursor();
-        draw_skills_tab( ui_skills, w_skills, *this, line, curtab, skillslist, TERMY - 1 );
+        draw_skills_tab( ui_skills, w_skills, *this, line, curtab, skillslist, TERMY - 1, ctxt );
     } );
 
     // TRAITS & BIONICS
@@ -1774,7 +1845,7 @@ void Character::disp_info( bool customize_character )
         borders.draw_border( w_traits_border );
         wnoutrefresh( w_traits_border );
         ui_traits.disable_cursor();
-        draw_traits_tab( ui_traits, w_traits, line, curtab, traitslist );
+        draw_traits_tab( ui_traits, w_traits, line, curtab, traitslist, ctxt );
     } );
 
     // BIONICS
@@ -1798,7 +1869,7 @@ void Character::disp_info( bool customize_character )
         borders.draw_border( w_bionics_border );
         wnoutrefresh( w_bionics_border );
         ui_bionics.disable_cursor();
-        draw_bionics_tab( ui_bionics, w_bionics, *this, line, curtab, bionicslist );
+        draw_bionics_tab( ui_bionics, w_bionics, *this, line, curtab, bionicslist, ctxt );
     } );
 
     // EFFECTS & PROFICIENCIES
@@ -1825,7 +1896,7 @@ void Character::disp_info( bool customize_character )
         borders.draw_border( w_effects_border );
         wnoutrefresh( w_effects_border );
         ui_effects.disable_cursor();
-        draw_effects_tab( ui_effects, w_effects, line, curtab, effect_name_and_text );
+        draw_effects_tab( ui_effects, w_effects, line, curtab, effect_name_and_text, ctxt );
     } );
 
     // PROFICIENCIES

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -473,7 +473,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
 
     if( line == 0 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                         _( "Strength affects your melee damage, the amount of weight you can carry, your total HP, "
                            "your resistance to many diseases, and the effectiveness of actions which require brute force." ) );
         print_colored_text( w_info, point( 1, 3 ), col_temp, c_light_gray,
@@ -486,7 +486,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
                             string_format( _( "Bash damage: <color_white>%.1f</color>" ), you.bonus_damage( false ) ) );
     } else if( line == 1 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                         _( "Dexterity affects your chance to hit in melee combat, helps you steady your "
                            "gun for ranged combat, and enhances many actions that require finesse." ) );
         print_colored_text( w_info, point( 1, 3 ), col_temp, c_light_gray,
@@ -499,7 +499,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
                                            you.throw_dispersion_per_dodge( false ) ) );
     } else if( line == 2 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                         _( "Intelligence is less important in most situations, but it is vital for more complex tasks like "
                            "electronics crafting.  It also affects how much skill you can pick up from reading a book." ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
@@ -508,7 +508,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
                             string_format( _( "Crafting bonus: <color_white>%d%%</color>" ), you.get_int() ) );
     } else if( line == 3 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                         _( "Perception is the most important stat for ranged combat.  It's also used for "
                            "detecting traps and other things of interest." ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
@@ -519,35 +519,35 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
         }
     } else if( line == 4 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        const int lines = fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                                           _( "Your weight is a general indicator of how much fat your body has stored up,"
                                              " which in turn shows how prepared you are to survive for a time without food."
                                              "  Having too much, or too little, can be unhealthy." ) );
-        fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+        fold_and_print( w_info, point( 1, 1 + lines ), getmaxx( w_info ) - 2, c_light_gray,
                         display::weight_long_description( you ) );
     } else if( line == 5 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                         _( "How healthy you feel.  Exercise, vitamins, sleep and not ingesting poison will increase this overtime." ) );
     } else if( line == 6 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        const int lines = fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                                           _( "Your height.  Simply how tall you are." ) );
-        fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+        fold_and_print( w_info, point( 1, 1 + lines ), getmaxx( w_info ) - 2, c_light_gray,
                         you.height_string() );
     } else if( line == 7 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        const int lines = fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                                           _( "This is how old you are." ) );
-        fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+        fold_and_print( w_info, point( 1, 1 + lines ), getmaxx( w_info ) - 2, c_light_gray,
                         you.age_string() );
     } else if( line == 8 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
+        const int lines = fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_magenta,
                                           _( "This is your blood type and Rh factor." ) );
-        fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+        fold_and_print( w_info, point( 1, 1 + lines ), getmaxx( w_info ) - 2, c_light_gray,
                         string_format( _( "Blood type: %s" ), io::enum_to_string( you.my_blood_type ) ) );
-        fold_and_print( w_info, point( 1, 2 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+        fold_and_print( w_info, point( 1, 2 + lines ), getmaxx( w_info ) - 2, c_light_gray,
                         string_format( _( "Rh factor: %s" ),
                                        you.blood_rh_factor ? _( "positive (+)" ) : _( "negative (-)" ) ) );
     }
@@ -584,7 +584,7 @@ static void draw_encumbrance_info( const catacurses::window &w_info, const Chara
     const std::vector<std::string> s = get_encumbrance_description( you, bp );
     const int winh = catacurses::getmaxy( w_info );
     const bool do_scroll = s.size() > static_cast<unsigned>( std::abs( winh ) );
-    const int winw = FULL_SCREEN_WIDTH - ( do_scroll ? 3 : 2 );
+    const int winw = getmaxx( w_info ) - ( do_scroll ? 1 : 2 );
     const int fline = do_scroll ? info_line % ( s.size() + 1 - winh ) : 0;
     const int lline = do_scroll ? fline + winh : s.size();
     for( int i = fline; i < lline; i++ ) {
@@ -639,7 +639,7 @@ static void draw_traits_info( const catacurses::window &w_info, const unsigned l
     if( line < traitslist.size() ) {
         const trait_and_var &cur = traitslist[line];
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, string_format( "%s: %s",
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_light_gray, string_format( "%s: %s",
                         colorize( cur.name(), cur.trait->get_display_color() ), cur.desc() ) );
     }
     wnoutrefresh( w_info );
@@ -718,7 +718,7 @@ static void draw_bionics_info( const catacurses::window &w_info, const unsigned 
     werase( w_info );
     if( line < bionicslist.size() ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, "%s",
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_light_gray, "%s",
                         bionicslist[line].description );
     }
     wnoutrefresh( w_info );
@@ -765,7 +765,7 @@ static void draw_effects_info( const catacurses::window &w_info, const unsigned 
     const size_t actual_size = effect_name_and_text.size();
     if( line < actual_size ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_light_gray,
                         effect_name_and_text[line].second );
     }
     wnoutrefresh( w_info );
@@ -899,7 +899,7 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
                                        level.knowledgeLevel(), level.knowledgeExperience() );
         }
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, info_text );
+        fold_and_print( w_info, point( 1, 0 ), getmaxx( w_info ) - 2, c_light_gray, info_text );
     }
     wnoutrefresh( w_info );
 }
@@ -1383,11 +1383,11 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
     return done;
 }
 
+/**
+* Calculate max allowed height of two windows sharing column space.
+*/
 static std::pair<unsigned, unsigned> calculate_shared_column_win_height(
     const unsigned available_height, unsigned first_win_size_y_max, unsigned second_win_size_y_max )
-/**
- * Calculate max allowed height of two windows sharing column space.
- */
 {
     if( ( second_win_size_y_max + 1 + first_win_size_y_max ) > available_height ) {
         // maximum space for either window if they're both the same size
@@ -1556,9 +1556,9 @@ void Character::disp_info( bool customize_character )
     const unsigned int info_win_size_y = 6;
 
     const unsigned int grid_height = 10;
+    const unsigned int encumbrance_height = 11;
 
-    const unsigned int infooffsetytop = grid_height + 2;
-    unsigned int infooffsetybottom = infooffsetytop + 1 + info_win_size_y;
+    const unsigned int infooffsetybottom = 3 + info_win_size_y;
 
     // Print name and header
     // Post-humanity trumps your pre-Cataclysm life
@@ -1618,13 +1618,36 @@ void Character::disp_info( bool customize_character )
     catacurses::window w_tip;
     ui_adaptor ui_tip;
     ui_tip.on_screen_resize( [&]( ui_adaptor & ui_tip ) {
-        w_tip = catacurses::newwin( 1, FULL_SCREEN_WIDTH + 1, point_zero );
+        w_tip = catacurses::newwin( 1, grid_width * 4 + 4, point_zero );
         ui_tip.position_from_window( w_tip );
     } );
     ui_tip.mark_resize();
     ui_tip.on_redraw( [&]( ui_adaptor & ui_tip ) {
         ui_tip.disable_cursor();
         draw_tip( w_tip, *this, race, ctxt, customize_character, tip_btn_highlight );
+    } );
+
+    // info panel
+    catacurses::window w_info;
+    catacurses::window w_info_border;
+    border_helper::border_info &border_info = borders.add_border();
+    ui_adaptor ui_info;
+    ui_info.on_screen_resize( [&]( ui_adaptor & ui_info ) {
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        w_info = catacurses::newwin( info_win_size_y, grid_width * 4 + 3, point( 0, 2 ) );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        w_info_border = catacurses::newwin( info_win_size_y + 2, grid_width * 4 + 4, point( 0, 1 ) );
+        border_info.set( point( -1, 1 ),
+                         point( grid_width * 4 + 5, info_win_size_y + 2 ) );
+        ui_info.position_from_window( w_info_border );
+    } );
+    ui_info.mark_resize();
+    ui_info.on_redraw( [&]( ui_adaptor & ui_info ) {
+        borders.draw_border( w_info_border );
+        wnoutrefresh( w_info_border );
+        ui_info.disable_cursor();
+        draw_info_window( w_info, *this, line, info_line, curtab,
+                          traitslist, bionicslist, effect_name_and_text, skillslist );
     } );
 
     // STATS
@@ -1634,15 +1657,15 @@ void Character::disp_info( bool customize_character )
     ui_adaptor ui_stats;
     ui_stats.on_screen_resize( [&]( ui_adaptor & ui_stats ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        w_stats = catacurses::newwin( grid_height, grid_width, point( 0, 1 ) );
+        w_stats = catacurses::newwin( grid_height, grid_width, point( 0, infooffsetybottom ) );
         // Every grid draws the bottom and right borders. The top and left borders
         // are either not displayed or drawn by another grid.
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        w_stats_border = catacurses::newwin( grid_height + 1, grid_width + 1, point( 0, 1 ) );
-        // But we need to specify the full border for border_helper to calculate the
-        // border connection.
+        w_stats_border = catacurses::newwin( grid_height + 2, grid_width + 1,
+                                             point( 0, infooffsetybottom - 1 ) );
+        // But we need to specify the full border for border_helper to calculate the border connection.
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        border_stats.set( point( -1, 0 ), point( grid_width + 2, grid_height + 2 ) );
+        border_stats.set( point( -1, infooffsetybottom - 1 ), point( grid_width + 2, grid_height + 2 ) );
         ui_stats.position_from_window( w_stats_border );
     } );
     ui_stats.mark_resize();
@@ -1651,6 +1674,71 @@ void Character::disp_info( bool customize_character )
         wnoutrefresh( w_stats_border );
         ui_stats.disable_cursor();
         draw_stats_tab( ui_stats, w_stats, *this, line, curtab, ctxt );
+    } );
+
+    // ENCUMBRANCE
+    catacurses::window w_encumb;
+    catacurses::window w_encumb_border;
+    border_helper::border_info &border_encumb = borders.add_border();
+    ui_adaptor ui_encumb;
+    ui_encumb.on_screen_resize( [&]( ui_adaptor & ui_encumb ) {
+        w_encumb = catacurses::newwin( encumbrance_height, grid_width,
+                                       point( 0, grid_height + infooffsetybottom + 1 ) );
+        w_encumb_border = catacurses::newwin( encumbrance_height + 2, grid_width + 1,
+                                              point( 0, grid_height + infooffsetybottom ) );
+        border_encumb.set( point( -1, grid_height + infooffsetybottom ),
+                           point( grid_width + 2, encumbrance_height + 2 ) );
+        ui_encumb.position_from_window( w_encumb_border );
+    } );
+    ui_encumb.mark_resize();
+    ui_encumb.on_redraw( [&]( ui_adaptor & ui_encumb ) {
+        borders.draw_border( w_encumb_border );
+        wnoutrefresh( w_encumb_border );
+        ui_encumb.disable_cursor();
+        draw_encumbrance_tab( ui_encumb, w_encumb, *this, line, curtab );
+    } );
+
+    // SPEED
+    catacurses::window w_speed;
+    catacurses::window w_speed_border;
+    border_helper::border_info &border_speed = borders.add_border();
+    ui_adaptor ui_speed;
+    ui_speed.on_screen_resize( [&]( ui_adaptor & ui_speed ) {
+        const int speed_top = grid_height + encumbrance_height + info_win_size_y;
+        w_speed = catacurses::newwin( TERMY - ( speed_top + 6 ), grid_width, point( 0, speed_top + 5 ) );
+        w_speed_border = catacurses::newwin( TERMY - ( speed_top + 4 ), grid_width + 1,
+                                             point( 0, speed_top + 4 ) );
+        border_speed.set( point( -1, speed_top + 4 ), point( grid_width + 2, TERMY - ( speed_top + 4 ) ) );
+        ui_speed.position_from_window( w_speed_border );
+    } );
+    ui_speed.mark_resize();
+    ui_speed.on_redraw( [&]( ui_adaptor & ui_speed ) {
+        borders.draw_border( w_speed_border );
+        wnoutrefresh( w_speed_border );
+        ui_speed.disable_cursor();
+        draw_speed_tab( w_speed, *this, speed_effects );
+    } );
+
+    // SKILLS
+    catacurses::window w_skills;
+    catacurses::window w_skills_border;
+    border_helper::border_info &border_skills = borders.add_border();
+    ui_adaptor ui_skills;
+    ui_skills.on_screen_resize( [&]( ui_adaptor & ui_skills ) {
+        w_skills = catacurses::newwin( TERMY - infooffsetybottom - 1, grid_width,
+                                       point( grid_width + 1, infooffsetybottom ) );
+        w_skills_border = catacurses::newwin( TERMY - infooffsetybottom + 1, grid_width + 2,
+                                              point( grid_width, infooffsetybottom - 1 ) );
+        border_skills.set( point( grid_width, infooffsetybottom - 1 ), point( grid_width + 2,
+                           TERMY - infooffsetybottom + 1 ) );
+        ui_skills.position_from_window( w_skills_border );
+    } );
+    ui_skills.mark_resize();
+    ui_skills.on_redraw( [&]( ui_adaptor & ui_skills ) {
+        borders.draw_border( w_skills_border );
+        wnoutrefresh( w_skills_border );
+        ui_skills.disable_cursor();
+        draw_skills_tab( ui_skills, w_skills, *this, line, curtab, skillslist, TERMY - 1 );
     } );
 
     // TRAITS & BIONICS
@@ -1665,11 +1753,11 @@ void Character::disp_info( bool customize_character )
         std::tie( trait_win_size_y, bionics_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, trait_win_size_y_max, bionics_win_size_y_max );
         w_traits = catacurses::newwin( trait_win_size_y, grid_width,
-                                       point( grid_width + 1, infooffsetybottom ) );
-        w_traits_border = catacurses::newwin( trait_win_size_y + 1, grid_width + 2,
-                                              point( grid_width, infooffsetybottom ) );
-        border_traits.set( point( grid_width, infooffsetybottom - 1 ),
-                           point( grid_width + 2, trait_win_size_y + 2 ) );
+                                       point( grid_width * 2 + 2, infooffsetybottom ) );
+        w_traits_border = catacurses::newwin( trait_win_size_y + 2, grid_width + 2,
+                                              point( grid_width * 2 + 1, infooffsetybottom - 1 ) );
+        border_traits.set( point( grid_width * 2 + 1, infooffsetybottom - 1 ), point( grid_width + 2,
+                           trait_win_size_y + 2 ) );
         ui_traits.position_from_window( w_traits_border );
     } );
     ui_traits.mark_resize();
@@ -1688,13 +1776,12 @@ void Character::disp_info( bool customize_character )
     ui_bionics.on_screen_resize( [&]( ui_adaptor & ui_bionics ) {
         std::tie( trait_win_size_y, bionics_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, trait_win_size_y_max, bionics_win_size_y_max );
-        w_bionics = catacurses::newwin( bionics_win_size_y, grid_width,
-                                        point( grid_width + 1,
-                                               infooffsetybottom + trait_win_size_y + 1 ) );
+        w_bionics = catacurses::newwin( bionics_win_size_y - 1, grid_width,
+                                        point( grid_width * 2 + 2, infooffsetybottom + trait_win_size_y + 1 ) );
         w_bionics_border = catacurses::newwin( bionics_win_size_y + 1, grid_width + 2,
-                                               point( grid_width, infooffsetybottom + trait_win_size_y + 1 ) );
-        border_bionics.set( point( grid_width, infooffsetybottom + trait_win_size_y ),
-                            point( grid_width + 2, bionics_win_size_y + 2 ) );
+                                               point( grid_width * 2 + 1, infooffsetybottom + trait_win_size_y ) );
+        border_bionics.set( point( grid_width * 2 + 1, infooffsetybottom + trait_win_size_y ),
+                            point( grid_width + 2, bionics_win_size_y + 1 ) );
         ui_bionics.position_from_window( w_bionics_border );
     } );
     ui_bionics.mark_resize();
@@ -1703,25 +1790,6 @@ void Character::disp_info( bool customize_character )
         wnoutrefresh( w_bionics_border );
         ui_bionics.disable_cursor();
         draw_bionics_tab( ui_bionics, w_bionics, *this, line, curtab, bionicslist );
-    } );
-
-    // ENCUMBRANCE
-    catacurses::window w_encumb;
-    catacurses::window w_encumb_border;
-    border_helper::border_info &border_encumb = borders.add_border();
-    ui_adaptor ui_encumb;
-    ui_encumb.on_screen_resize( [&]( ui_adaptor & ui_encumb ) {
-        w_encumb = catacurses::newwin( grid_height, grid_width, point( grid_width + 1, 1 ) );
-        w_encumb_border = catacurses::newwin( grid_height + 1, grid_width + 1, point( grid_width + 1, 1 ) );
-        border_encumb.set( point( grid_width, 0 ), point( grid_width + 2, grid_height + 2 ) );
-        ui_encumb.position_from_window( w_encumb_border );
-    } );
-    ui_encumb.mark_resize();
-    ui_encumb.on_redraw( [&]( ui_adaptor & ui_encumb ) {
-        borders.draw_border( w_encumb_border );
-        wnoutrefresh( w_encumb_border );
-        ui_encumb.disable_cursor();
-        draw_encumbrance_tab( ui_encumb, w_encumb, *this, line, curtab );
     } );
 
     // EFFECTS & PROFICIENCIES
@@ -1736,11 +1804,11 @@ void Character::disp_info( bool customize_character )
         std::tie( effect_win_size_y, proficiency_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, effect_win_size_y_max, proficiency_win_size_y_max );
         w_effects = catacurses::newwin( effect_win_size_y, grid_width,
-                                        point( grid_width * 2 + 2, infooffsetybottom ) );
-        w_effects_border = catacurses::newwin( effect_win_size_y + 1, grid_width + 2,
-                                               point( grid_width * 2 + 1, infooffsetybottom ) );
-        border_effects.set( point( grid_width * 2 + 1, infooffsetybottom - 1 ),
-                            point( grid_width + 2, effect_win_size_y + 2 ) );
+                                        point( grid_width * 3 + 3, infooffsetybottom ) );
+        w_effects_border = catacurses::newwin( effect_win_size_y + 2, grid_width + 2,
+                                               point( grid_width * 3 + 2, infooffsetybottom - 1 ) );
+        border_effects.set( point( grid_width * 3 + 2, infooffsetybottom - 1 ), point( grid_width + 2,
+                            effect_win_size_y + 2 ) );
         ui_effects.position_from_window( w_effects_border );
     } );
     ui_effects.mark_resize();
@@ -1759,13 +1827,12 @@ void Character::disp_info( bool customize_character )
     ui_proficiencies.on_screen_resize( [&]( ui_adaptor & ui_proficiencies ) {
         std::tie( effect_win_size_y, proficiency_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, effect_win_size_y_max, proficiency_win_size_y_max );
-        const point profstart = point( grid_width * 2 + 2, infooffsetybottom + effect_win_size_y + 1 );
-        w_proficiencies = catacurses::newwin( proficiency_win_size_y, grid_width,
-                                              profstart );
+        w_proficiencies = catacurses::newwin( proficiency_win_size_y - 1, grid_width,
+                                              point( grid_width * 3 + 3, infooffsetybottom + effect_win_size_y + 1 ) );
         w_proficiencies_border = catacurses::newwin( proficiency_win_size_y + 1, grid_width + 2,
-                                 profstart + point_west );
-        border_proficiencies.set( profstart + point_north_west, point( grid_width + 2,
-                                  proficiency_win_size_y + 2 ) );
+                                 point( grid_width * 3 + 2, infooffsetybottom + effect_win_size_y ) );
+        border_proficiencies.set( point( grid_width * 3 + 2, infooffsetybottom + effect_win_size_y ),
+                                  point( grid_width + 2, proficiency_win_size_y + 1 ) );
         ui_proficiencies.position_from_window( w_proficiencies_border );
     } );
     ui_proficiencies.mark_resize();
@@ -1774,78 +1841,6 @@ void Character::disp_info( bool customize_character )
         wnoutrefresh( w_proficiencies_border );
         ui_proficiencies.disable_cursor();
         draw_proficiencies_tab( ui_proficiencies, w_proficiencies, line, *this, curtab, ctxt );
-    } );
-
-    // SKILLS
-    unsigned int skill_win_size_y = 0;
-    catacurses::window w_skills;
-    catacurses::window w_skills_border;
-    border_helper::border_info &border_skills = borders.add_border();
-    ui_adaptor ui_skills;
-    ui_skills.on_screen_resize( [&]( ui_adaptor & ui_skills ) {
-        const unsigned int maxy = static_cast<unsigned>( TERMY );
-        skill_win_size_y = skill_win_size_y_max;
-        if( skill_win_size_y + infooffsetybottom > maxy ) {
-            skill_win_size_y = maxy - infooffsetybottom;
-        }
-        w_skills = catacurses::newwin( skill_win_size_y, grid_width,
-                                       point( 0, infooffsetybottom ) );
-        w_skills_border = catacurses::newwin( skill_win_size_y + 1, grid_width + 1,
-                                              point( 0, infooffsetybottom ) );
-        border_skills.set( point( -1, infooffsetybottom - 1 ),
-                           point( grid_width + 2, skill_win_size_y + 2 ) );
-        ui_skills.position_from_window( w_skills_border );
-    } );
-    ui_skills.mark_resize();
-    ui_skills.on_redraw( [&]( ui_adaptor & ui_skills ) {
-        borders.draw_border( w_skills_border );
-        wnoutrefresh( w_skills_border );
-        ui_skills.disable_cursor();
-        draw_skills_tab( ui_skills, w_skills, *this, line, curtab, skillslist, skill_win_size_y );
-    } );
-
-    // info panel
-    catacurses::window w_info;
-    catacurses::window w_info_border;
-    border_helper::border_info &border_info = borders.add_border();
-    ui_adaptor ui_info;
-    ui_info.on_screen_resize( [&]( ui_adaptor & ui_info ) {
-        w_info = catacurses::newwin( info_win_size_y, FULL_SCREEN_WIDTH,
-                                     point( 0, infooffsetytop ) );
-        w_info_border = catacurses::newwin( info_win_size_y + 1, FULL_SCREEN_WIDTH + 1,
-                                            point( 0, infooffsetytop ) );
-        border_info.set( point( -1, infooffsetytop - 1 ),
-                         point( FULL_SCREEN_WIDTH + 2, info_win_size_y + 2 ) );
-        ui_info.position_from_window( w_info_border );
-    } );
-    ui_info.mark_resize();
-    ui_info.on_redraw( [&]( ui_adaptor & ui_info ) {
-        borders.draw_border( w_info_border );
-        wnoutrefresh( w_info_border );
-        ui_info.disable_cursor();
-        draw_info_window( w_info, *this, line, info_line, curtab,
-                          traitslist, bionicslist, effect_name_and_text, skillslist );
-    } );
-
-    // SPEED
-    catacurses::window w_speed;
-    catacurses::window w_speed_border;
-    border_helper::border_info &border_speed = borders.add_border();
-    ui_adaptor ui_speed;
-    ui_speed.on_screen_resize( [&]( ui_adaptor & ui_speed ) {
-        w_speed = catacurses::newwin( grid_height, grid_width, point( grid_width * 2 + 2, 1 ) );
-        w_speed_border = catacurses::newwin( grid_height + 1, grid_width + 1,
-                                             point( grid_width * 2 + 2, 1 ) );
-        border_speed.set( point( grid_width * 2 + 1, 0 ),
-                          point( grid_width + 2, grid_height + 2 ) );
-        ui_speed.position_from_window( w_speed_border );
-    } );
-    ui_speed.mark_resize();
-    ui_speed.on_redraw( [&]( ui_adaptor & ui_speed ) {
-        borders.draw_border( w_speed_border );
-        wnoutrefresh( w_speed_border );
-        ui_speed.disable_cursor();
-        draw_speed_tab( w_speed, *this, speed_effects );
     } );
 
     bool done = false;

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1635,8 +1635,9 @@ void Character::disp_info( bool customize_character )
         w_info = catacurses::newwin( info_win_size_y, grid_width * 4 + 3, point( 0, 2 ) );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         w_info_border = catacurses::newwin( info_win_size_y + 2, grid_width * 4 + 4, point( 0, 1 ) );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
         border_info.set( point( -1, 1 ),
-                         point( grid_width * 4 + 5, info_win_size_y + 2 ) );
+                         point( grid_width * 4 + 5, infooffsetybottom - 1 ) );
         ui_info.position_from_window( w_info_border );
     } );
     ui_info.mark_resize();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -69,8 +69,6 @@ static const std::string title_BIONICS = translate_marker( "BIONICS" );
 static const std::string title_TRAITS = translate_marker( "TRAITS" );
 static const std::string title_PROFICIENCIES = translate_marker( "PROFICIENCIES" );
 
-static const unsigned int grid_width = 26;
-
 // Rescale temperature value to one that the player sees
 static int temperature_print_rescaling( int temp )
 {
@@ -783,6 +781,7 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                              std::vector<HeaderSkill> &skillslist,
                              const size_t skill_win_size_y )
 {
+    unsigned int grid_width = get_option<int>( "COLUMN_WIDTH" );
     const int col_width = getmaxx( w_skills ) - 1;
 
     werase( w_skills );
@@ -1613,6 +1612,8 @@ void Character::disp_info( bool customize_character )
     unsigned int line = 0;
     unsigned int info_line = 0;
     int tip_btn_highlight = -1;
+
+    unsigned int grid_width = get_option<int>( "COLUMN_WIDTH" );
 
     catacurses::window w_tip;
     ui_adaptor ui_tip;

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1705,10 +1705,12 @@ void Character::disp_info( bool customize_character )
     ui_adaptor ui_speed;
     ui_speed.on_screen_resize( [&]( ui_adaptor & ui_speed ) {
         const int speed_top = grid_height + encumbrance_height + info_win_size_y;
-        w_speed = catacurses::newwin( TERMY - ( speed_top + 6 ), grid_width, point( 0, speed_top + 5 ) );
-        w_speed_border = catacurses::newwin( TERMY - ( speed_top + 4 ), grid_width + 1,
+        w_speed = catacurses::newwin( std::max( 1, TERMY - ( speed_top + 6 ) ), grid_width,
+                                      point( 0, speed_top + 5 ) );
+        w_speed_border = catacurses::newwin( std::max( 1, TERMY - ( speed_top + 4 ) ), grid_width + 1,
                                              point( 0, speed_top + 4 ) );
-        border_speed.set( point( -1, speed_top + 4 ), point( grid_width + 2, TERMY - ( speed_top + 4 ) ) );
+        border_speed.set( point( -1, speed_top + 4 ),
+                          point( grid_width + 2, std::max( 1, TERMY - ( speed_top + 4 ) ) ) );
         ui_speed.position_from_window( w_speed_border );
     } );
     ui_speed.mark_resize();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1532,7 +1532,7 @@ void Character::disp_info( bool customize_character )
             bionicslist.push_back( { pair.first.name, pair.first.description, pair.second } );
         }
     }
-    const unsigned int bionics_win_size_y_max = 2 + bionicslist.size();
+    const unsigned int bionics_win_size_y_max = 3 + bionicslist.size();
 
     const std::vector<const Skill *> player_skill = Skill::get_skills_sorted_by(
     [&]( const Skill & a, const Skill & b ) {
@@ -1782,12 +1782,12 @@ void Character::disp_info( bool customize_character )
     ui_bionics.on_screen_resize( [&]( ui_adaptor & ui_bionics ) {
         std::tie( trait_win_size_y, bionics_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, trait_win_size_y_max, bionics_win_size_y_max );
-        w_bionics = catacurses::newwin( bionics_win_size_y, grid_width,
+        w_bionics = catacurses::newwin( bionics_win_size_y - 1, grid_width,
                                         point( grid_width * 2 + 2, infooffsetybottom + trait_win_size_y + 1 ) );
-        w_bionics_border = catacurses::newwin( bionics_win_size_y + 2, grid_width + 2,
+        w_bionics_border = catacurses::newwin( bionics_win_size_y + 1, grid_width + 2,
                                                point( grid_width * 2 + 1, infooffsetybottom + trait_win_size_y ) );
         border_bionics.set( point( grid_width * 2 + 1, infooffsetybottom + trait_win_size_y ),
-                            point( grid_width + 2, bionics_win_size_y + 2 ) );
+                            point( grid_width + 2, bionics_win_size_y + 1 ) );
         ui_bionics.position_from_window( w_bionics_border );
     } );
     ui_bionics.mark_resize();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1636,8 +1636,7 @@ void Character::disp_info( bool customize_character )
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         w_info_border = catacurses::newwin( info_win_size_y + 2, grid_width * 4 + 4, point( 0, 1 ) );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        border_info.set( point( -1, 1 ),
-                         point( grid_width * 4 + 5, infooffsetybottom - 1 ) );
+        border_info.set( point( -1, 1 ), point( grid_width * 4 + 5, infooffsetybottom - 1 ) );
         ui_info.position_from_window( w_info_border );
     } );
     ui_info.mark_resize();
@@ -1728,8 +1727,8 @@ void Character::disp_info( bool customize_character )
                                        point( grid_width + 1, infooffsetybottom ) );
         w_skills_border = catacurses::newwin( TERMY - infooffsetybottom + 1, grid_width + 2,
                                               point( grid_width, infooffsetybottom - 1 ) );
-        border_skills.set( point( grid_width, infooffsetybottom - 1 ), point( grid_width + 2,
-                           TERMY - infooffsetybottom + 1 ) );
+        border_skills.set( point( grid_width, infooffsetybottom - 1 ),
+                           point( grid_width + 2, TERMY - infooffsetybottom + 1 ) );
         ui_skills.position_from_window( w_skills_border );
     } );
     ui_skills.mark_resize();
@@ -1755,8 +1754,8 @@ void Character::disp_info( bool customize_character )
                                        point( grid_width * 2 + 2, infooffsetybottom ) );
         w_traits_border = catacurses::newwin( trait_win_size_y + 2, grid_width + 2,
                                               point( grid_width * 2 + 1, infooffsetybottom - 1 ) );
-        border_traits.set( point( grid_width * 2 + 1, infooffsetybottom - 1 ), point( grid_width + 2,
-                           trait_win_size_y + 2 ) );
+        border_traits.set( point( grid_width * 2 + 1, infooffsetybottom - 1 ),
+                           point( grid_width + 2, trait_win_size_y + 2 ) );
         ui_traits.position_from_window( w_traits_border );
     } );
     ui_traits.mark_resize();
@@ -1775,12 +1774,12 @@ void Character::disp_info( bool customize_character )
     ui_bionics.on_screen_resize( [&]( ui_adaptor & ui_bionics ) {
         std::tie( trait_win_size_y, bionics_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, trait_win_size_y_max, bionics_win_size_y_max );
-        w_bionics = catacurses::newwin( bionics_win_size_y - 1, grid_width,
+        w_bionics = catacurses::newwin( bionics_win_size_y, grid_width,
                                         point( grid_width * 2 + 2, infooffsetybottom + trait_win_size_y + 1 ) );
-        w_bionics_border = catacurses::newwin( bionics_win_size_y + 1, grid_width + 2,
+        w_bionics_border = catacurses::newwin( bionics_win_size_y + 2, grid_width + 2,
                                                point( grid_width * 2 + 1, infooffsetybottom + trait_win_size_y ) );
         border_bionics.set( point( grid_width * 2 + 1, infooffsetybottom + trait_win_size_y ),
-                            point( grid_width + 2, bionics_win_size_y + 1 ) );
+                            point( grid_width + 2, bionics_win_size_y + 2 ) );
         ui_bionics.position_from_window( w_bionics_border );
     } );
     ui_bionics.mark_resize();
@@ -1806,8 +1805,8 @@ void Character::disp_info( bool customize_character )
                                         point( grid_width * 3 + 3, infooffsetybottom ) );
         w_effects_border = catacurses::newwin( effect_win_size_y + 2, grid_width + 2,
                                                point( grid_width * 3 + 2, infooffsetybottom - 1 ) );
-        border_effects.set( point( grid_width * 3 + 2, infooffsetybottom - 1 ), point( grid_width + 2,
-                            effect_win_size_y + 2 ) );
+        border_effects.set( point( grid_width * 3 + 2, infooffsetybottom - 1 ),
+                            point( grid_width + 2, effect_win_size_y + 2 ) );
         ui_effects.position_from_window( w_effects_border );
     } );
     ui_effects.mark_resize();
@@ -1826,12 +1825,12 @@ void Character::disp_info( bool customize_character )
     ui_proficiencies.on_screen_resize( [&]( ui_adaptor & ui_proficiencies ) {
         std::tie( effect_win_size_y, proficiency_win_size_y ) = calculate_shared_column_win_height(
                     TERMY - infooffsetybottom, effect_win_size_y_max, proficiency_win_size_y_max );
-        w_proficiencies = catacurses::newwin( proficiency_win_size_y - 1, grid_width,
+        w_proficiencies = catacurses::newwin( proficiency_win_size_y, grid_width,
                                               point( grid_width * 3 + 3, infooffsetybottom + effect_win_size_y + 1 ) );
-        w_proficiencies_border = catacurses::newwin( proficiency_win_size_y + 1, grid_width + 2,
+        w_proficiencies_border = catacurses::newwin( proficiency_win_size_y + 2, grid_width + 2,
                                  point( grid_width * 3 + 2, infooffsetybottom + effect_win_size_y ) );
         border_proficiencies.set( point( grid_width * 3 + 2, infooffsetybottom + effect_win_size_y ),
-                                  point( grid_width + 2, proficiency_win_size_y + 1 ) );
+                                  point( grid_width + 2, proficiency_win_size_y + 2 ) );
         ui_proficiencies.position_from_window( w_proficiencies_border );
     } );
     ui_proficiencies.mark_resize();


### PR DESCRIPTION
#### Summary
Interface "Larger and reorganized player info menu"

#### Purpose of change
Player info menu (@ by default) was designed for outdated 80x24 terminal size and as such has several issues with our current situation.

- Encumbrance and warmth panel has space only for 9 body parts while there's 10 body parts to display. This leads to necessity of scrolling through the panel.
![изображение](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/4b4ed6ee-d0b3-4ec7-8824-57db2ad5c498)

- Speed panel has space only for 7 effects, so if there's more than that, 8th and others ain't displayed at all. For example, there's 8th `Webbed` effect which isn't displayed in Speed panel.
![изображение](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/066895b3-2c53-485d-bff8-2cab1bd88af8)

- Lots of simultaneous mutations and bionics (and also effects and proficiencies) leads to necessity of scrolling through the panels as there's too small space for them.
- Overall the old layout with its 80x24 limit is hostile towards non-English languages and doesn't have much potential for improvement. In the new layout columns width can be easily expanded if needed.

#### Describe the solution
- Moved Info panel from the middle of the screen to the top.
- Increased overall amount of columns from 3 to 4. This won't fit in "default" 80x24 terminal size, but I think nobody uses this size these days. This also hides the center of the screen with a player sprite, but I don't think it's too big of a deal.
- Reorganized panels layout so they take all available screen height.
- Increased height of Encumbrance and warmth panel from 10 to 11 lines to remove the scrollbar.
- Added hotkeys for fast switching between the panels, binded to F1-F7 by default.
- Added an option to customize grid width in player info menu, ranging from 26 (default) to 50 columns.

#### Describe alternatives you've considered
Moved Info panel to the bottom of the screen instead.

#### Testing
Started game, got many mutations, bionics, and effects and checked how they all looked like in the new layout.

#### Additional context
Old layout (for comparison)
![изображение](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/b5373d20-742e-4d81-91fc-2f68fbfa2004)

New layout
![изображение](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/64b1f1fd-8e36-4766-8730-7c26582c7179)

New layout for the character without bionics or proficiencies and small amount of traits
![изображение](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/b2eb757f-cb52-4867-8e7d-990b49676d09)

New layout with grid width of 30
![изображение](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/8bc88c3c-89b0-41f1-afd6-38842e62c40c)

New layout with grid width of 40
![изображение](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/c808187b-7873-4531-84b6-b5151a5653e7)