### PR TITLE
Mounts don't fear hallucinations no more

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1470,6 +1470,9 @@ bool Character::check_mount_will_move( const tripoint &dest_loc )
     }
     if( mounted_creature && mounted_creature->type->has_fear_trigger( mon_trigger::HOSTILE_CLOSE ) ) {
         for( const monster &critter : g->all_monsters() ) {
+            if( critter.is_hallucination() ) {
+                continue;
+            }
             Attitude att = critter.attitude_to( *this );
             if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 15 &&
                 rl_dist( dest_loc, critter.pos() ) < rl_dist( pos(), critter.pos() ) ) {
@@ -1498,6 +1501,9 @@ bool Character::check_mount_is_spooked()
         const creature_size mount_size = mounted_creature->get_size();
         const bool saddled = mounted_creature->has_effect( effect_monster_saddled );
         for( const monster &critter : g->all_monsters() ) {
+            if( critter.is_hallucination() ) {
+                continue;
+            }
             double chance = 1.0;
             Attitude att = critter.attitude_to( *this );
             // actually too close now - horse might spook.
@@ -1514,6 +1520,9 @@ bool Character::check_mount_is_spooked()
                 }
                 chance = std::max( 1.0, chance );
                 if( x_in_y( chance, 100.0 ) ) {
+                    add_msg_player_or_npc( m_bad, _( "%s got spooked by %s and threw you to the ground!" ),
+                                           _( "%s got spooked by %s and threw <npcname> to the ground!" ),
+                                           mounted_creature->disp_name( false, true ), critter.disp_name() );
                     forced_dismount();
                     return true;
                 }


### PR DESCRIPTION
#### Summary
Bugfixes "Mounts don't fear hallucinations no more"

#### Purpose of change
Mounts shouldn't fear player's hallucinations.

#### Describe the solution
Added check for hallucination monsters in `check_mount_is_spooked` and also in `check_mount_will_move` functions. Also added a message indicating that the mount was actually spooked.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned a horse, a cattle fodder, a tack, and a saddle. Feed the horse with the fodder. Mounted the horse. Debug-spawned hallucination skeletal juggernaut. Moved around the juggernaut. No forced dismount.
Debug-spawned real juggernaut. Moved around it. After some time my horse got spooked and threw me to the ground.

#### Additional context
None.