### PR TITLE
Fungal infestation map extra

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -574,6 +574,15 @@
     "flags": [ "MAN_MADE" ]
   },
   {
+    "id": "mx_fungal_zone",
+    "type": "map_extra",
+    "name": { "str": "Fungal infestation" },
+    "description": "Fungal-infested location.",
+    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_fungal_zone" },
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "MAN_MADE" ]
+  },
+  {
     "id": "mx_reed",
     "type": "map_extra",
     "name": { "str": "Reed" },

--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -8,6 +8,7 @@
       { "terrain": "road", "locations": [ "forest_trail" ], "basic_cost": 25 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
       { "terrain": "road_nesw_manhole", "locations": [  ] },
+      { "terrain": "city_center", "locations": [ "field", "road" ] },
       { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120 },
       { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120 }
     ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -53,6 +53,18 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "city_center",
+    "copy-from": "generic_transportation",
+    "name": "road",
+    "sym": "┼",
+    "color": "dark_gray",
+    "see_cost": 2,
+    "extras": "city_center",
+    "mapgen": [ { "method": "builtin", "name": "road_four_way" } ],
+    "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "overmap_terrain",
     "abstract": "generic_bridge",
     "copy-from": "generic_transportation",
     "name": "bridge",

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -758,6 +758,7 @@
         }
       },
       "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 100 } },
+      "city_center": { "chance": 20, "extras": { "mx_fungal_zone": 100 } },
       "road_nesw_manhole": { "chance": 20, "extras": { "mx_city_trap": 100 } },
       "build": {
         "chance": 90,

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2690,6 +2690,11 @@ static bool mx_fungal_zone( map &/*m*/, const tripoint &abs_sub )
         }
     }
 
+    // If there's no parks in the city, bail out
+    if( valid_omt.empty() ) {
+        return false;
+    }
+
     const tripoint_abs_omt park_omt = random_entry( valid_omt, city_center_omt );
 
     tinymap fungal_map;

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -122,6 +122,7 @@ static const map_extra_id map_extra_mx_clay_deposit( "mx_clay_deposit" );
 static const map_extra_id map_extra_mx_clearcut( "mx_clearcut" );
 static const map_extra_id map_extra_mx_corpses( "mx_corpses" );
 static const map_extra_id map_extra_mx_dead_vegetation( "mx_dead_vegetation" );
+static const map_extra_id map_extra_mx_fungal_zone( "mx_fungal_zone" );
 static const map_extra_id map_extra_mx_grove( "mx_grove" );
 static const map_extra_id map_extra_mx_helicopter( "mx_helicopter" );
 static const map_extra_id map_extra_mx_house_wasp( "mx_house_wasp" );
@@ -155,6 +156,7 @@ static const mongroup_id GROUP_TURRET_SPEAKER( "GROUP_TURRET_SPEAKER" );
 static const mongroup_id GROUP_WASP_GUARD( "GROUP_WASP_GUARD" );
 static const mongroup_id GROUP_WASP_QUEEN( "GROUP_WASP_QUEEN" );
 
+static const mtype_id mon_fungaloid_queen( "mon_fungaloid_queen" );
 static const mtype_id mon_turret_riot( "mon_turret_riot" );
 static const mtype_id mon_turret_searchlight( "mon_turret_searchlight" );
 static const mtype_id mon_wolf( "mon_wolf" );
@@ -2670,6 +2672,55 @@ static bool mx_city_trap( map &/*m*/, const tripoint &abs_sub )
     return true;
 }
 
+static bool mx_fungal_zone( map &/*m*/, const tripoint &abs_sub )
+{
+    //First, find a city
+    // TODO: fix point types
+    const city_reference c = overmap_buffer.closest_city( tripoint_abs_sm( abs_sub ) );
+    const tripoint_abs_omt city_center_omt = project_to<coords::omt>( c.abs_sm_pos );
+
+    //Then find out which types of parks (defined in regional settings) exist in this city
+    std::vector<tripoint_abs_omt> valid_omt;
+    for( const tripoint_abs_omt &p : points_in_radius( city_center_omt, c.city->size ) ) {
+        const auto &parks = overmap_buffer.get_existing_om_global( p ).
+                            om->get_settings().city_spec.parks.all;
+        if( std::find( parks.begin(), parks.end(),
+                       overmap_buffer.ter( p ).obj().get_type_id().str() ) != parks.end() ) {
+            valid_omt.push_back( p );
+        }
+    }
+
+    const tripoint_abs_omt park_omt = random_entry( valid_omt, city_center_omt );
+
+    tinymap fungal_map;
+    fungal_map.load( project_to<coords::sm>( park_omt ), false );
+
+    // Then find suitable location for fungal spire to spawn (grass, dirt etc)
+    const tripoint submap_center = { SEEX, SEEY, abs_sub.z };
+    std::vector<tripoint> suitable_locations;
+    for( const tripoint &loc : fungal_map.points_in_radius( submap_center, 10 ) ) {
+        if( fungal_map.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, loc ) ) {
+            suitable_locations.push_back( loc );
+        }
+    }
+
+    // If there's no suitable location found, bail out
+    if( suitable_locations.empty() ) {
+        return false;
+    }
+
+    const tripoint suitable_location = random_entry( suitable_locations, submap_center );
+    fungal_map.add_spawn( mon_fungaloid_queen, 1, suitable_location );
+    fungal_map.place_spawns( GROUP_FUNGI_FUNGALOID, 1,
+                             suitable_location.xy() + point_north_west,
+                             suitable_location.xy() + point_south_east,
+                             3, true );
+
+    fungal_map.save();
+
+    return true;
+}
+
 static FunctionMap builtin_functions = {
     { map_extra_mx_null, mx_null },
     { map_extra_mx_roadworks, mx_roadworks },
@@ -2696,6 +2747,7 @@ static FunctionMap builtin_functions = {
     { map_extra_mx_looters, mx_looters },
     { map_extra_mx_corpses, mx_corpses },
     { map_extra_mx_city_trap, mx_city_trap },
+    { map_extra_mx_fungal_zone, mx_fungal_zone },
     { map_extra_mx_reed, mx_reed }
 };
 

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -46,6 +46,7 @@ static const item_group_id Item_spawn_data_wreckage( "wreckage" );
 static const mongroup_id GROUP_FAMOUS_SINGERS( "GROUP_FAMOUS_SINGERS" );
 static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 
+static const oter_str_id oter_city_center( "city_center" );
 static const oter_str_id oter_crater( "crater" );
 static const oter_str_id oter_crater_core( "crater_core" );
 static const oter_str_id oter_forest_thick( "forest_thick" );
@@ -407,7 +408,8 @@ void mapgen_road( mapgendata &dat )
             // 4-way intersection
             for( int dir = 0; dir < 8; dir++ ) {
                 fourways_neswx[dir] = ( dat.t_nesw[dir] == oter_road_nesw ||
-                                        dat.t_nesw[dir] == oter_road_nesw_manhole );
+                                        dat.t_nesw[dir] == oter_road_nesw_manhole ||
+                                        dat.t_nesw[dir] == oter_city_center );
             }
             // is this the middle, or which side or corner, of a plaza?
             plaza_dir = compare_neswx( fourways_neswx, {1, 1, 1, 1, 1, 1, 1, 1} ) ? 8 :

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -75,6 +75,7 @@ static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 static const oter_str_id oter_central_lab( "central_lab" );
 static const oter_str_id oter_central_lab_core( "central_lab_core" );
 static const oter_str_id oter_central_lab_train_depot( "central_lab_train_depot" );
+static const oter_str_id oter_city_center( "city_center" );
 static const oter_str_id oter_empty_rock( "empty_rock" );
 static const oter_str_id oter_field( "field" );
 static const oter_str_id oter_forest( "forest" );
@@ -1018,7 +1019,7 @@ bool oter_t::type_is( const oter_type_t &type ) const
 bool oter_t::has_connection( om_direction::type dir ) const
 {
     // TODO: It's a DAMN UGLY hack. Remove it as soon as possible.
-    if( id == oter_road_nesw_manhole ) {
+    if( id == oter_road_nesw_manhole || id == oter_city_center ) {
         return true;
     }
     return om_lines::has_segment( line, dir );
@@ -5173,6 +5174,10 @@ void overmap::place_cities()
             do {
                 build_city_street( local_road, tmp.pos, tmp.size, cur_dir, tmp );
             } while( ( cur_dir = om_direction::turn_right( cur_dir ) ) != start_dir );
+
+            // Replace city's original intersection OMT with a dedicated 'city_center' OMT
+            // This allows setting map extras specifically to cities (or their centers)
+            ter_set( tripoint_om_omt( tmp.pos, 0 ), oter_city_center );
         }
     }
 }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -43,11 +43,11 @@
 
 class map_extra;
 
-static const oter_type_str_id oter_type_city_center( "city_center" );
 static const oter_type_str_id oter_type_bridge( "bridge" );
 static const oter_type_str_id oter_type_bridge_road( "bridge_road" );
 static const oter_type_str_id oter_type_bridgehead_ground( "bridgehead_ground" );
 static const oter_type_str_id oter_type_bridgehead_ramp( "bridgehead_ramp" );
+static const oter_type_str_id oter_type_city_center( "city_center" );
 static const oter_type_str_id oter_type_deep_rock( "deep_rock" );
 static const oter_type_str_id oter_type_empty_rock( "empty_rock" );
 static const oter_type_str_id oter_type_field( "field" );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -43,6 +43,7 @@
 
 class map_extra;
 
+static const oter_type_str_id oter_type_city_center( "city_center" );
 static const oter_type_str_id oter_type_bridge( "bridge" );
 static const oter_type_str_id oter_type_bridge_road( "bridge_road" );
 static const oter_type_str_id oter_type_bridgehead_ground( "bridgehead_ground" );
@@ -919,7 +920,8 @@ static int get_terrain_cost( const tripoint_abs_omt &omt_pos, const overmap_path
         ( oter->get_type_id() == oter_type_bridge_road ) ||
         ( oter->get_type_id() == oter_type_bridgehead_ground ) ||
         ( oter->get_type_id() == oter_type_bridgehead_ramp ) ||
-        ( oter->get_type_id() == oter_type_road_nesw_manhole ) ) {
+        ( oter->get_type_id() == oter_type_road_nesw_manhole ) ||
+        ( oter->get_type_id() == oter_type_city_center ) ) {
         return params.road_cost;
     } else if( oter->get_type_id() == oter_type_field ) {
         return params.field_cost;


### PR DESCRIPTION
#### Summary
Content "Fungal infestation map extra"

#### Purpose of change
Add some fungal fun to cities.

#### Describe the solution
- Added a special `city_center` OMT which can be assigned as a place for guaranteed spawn of map extras inside city borders.
- Added fungal infestation map extra. 5% chance to spawn in every city. It will spawn only if there's at least one park found in the city (the list of parks is defined in regional settings). It will search for suitable location (grass, dirt, sand etc) inside one of the parks and if search is successful, it will spawn fungal spire on suitable tile and 1..3 fungaloids around.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned map extra in a city with a park. Checked that fungal spire and fungaloids are correctly spawned on random suitable location.
Also teleported around the world and searched for map extra to spawn naturally.

#### Additional context
Screenshot of fungal spire (circled in yellow) that spawned in a city's park and got a rather big territory after ~6 ingame hours.
![16953266592820](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/b4407a40-3742-45a1-be4b-da9bef8083fa)