### PR TITLE
More cases for not logging monster attacks or NPCs trying to break free from various traps and debilitating effects

### DIFF
--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -6,6 +6,7 @@
 #include "messages.h"
 #include "monster.h"
 #include "mtype.h"
+#include "options.h"
 #include "output.h"
 
 static const efftype_id effect_beartrap( "beartrap" );
@@ -50,8 +51,9 @@ void Character::try_remove_downed()
     } else {
         add_msg_player_or_npc( m_good,
                                has_flag( json_flag_DOWNED_RECOVERY ) ? _( "You deftly roll to your feet." ) : _( "You stand up." ),
+                               get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
                                has_flag( json_flag_DOWNED_RECOVERY ) ? _( "<npcname> deftly rolls to their feet." ) :
-                               _( "<npcname> stands up." ) );
+                               _( "<npcname> stands up." ) : "" );
         remove_effect( effect_downed );
     }
 }
@@ -80,7 +82,8 @@ void Character::try_remove_bear_trap()
         if( can_escape_trap( 100 ) ) {
             remove_effect( effect_beartrap );
             add_msg_player_or_npc( m_good, _( "You free yourself from the bear trap!" ),
-                                   _( "<npcname> frees themselves from the bear trap!" ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> frees themselves from the bear trap!" ) : "" );
         } else {
             add_msg_if_player( m_bad,
                                _( "You try to free yourself from the bear trap, but can't get loose!" ) );
@@ -104,7 +107,8 @@ void Character::try_remove_lightsnare()
         if( can_escape_trap( 12 ) ) {
             remove_effect( effect_lightsnare );
             add_msg_player_or_npc( m_good, _( "You free yourself from the light snare!" ),
-                                   _( "<npcname> frees themselves from the light snare!" ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> frees themselves from the light snare!" ) : "" );
             item string( "string_36", calendar::turn );
             item snare( "snare_trigger", calendar::turn );
             here.add_item_or_charges( pos(), string );
@@ -134,7 +138,8 @@ void Character::try_remove_heavysnare()
         if( can_escape_trap( 32 - dex_cur, true ) ) {
             remove_effect( effect_heavysnare );
             add_msg_player_or_npc( m_good, _( "You free yourself from the heavy snare!" ),
-                                   _( "<npcname> frees themselves from the heavy snare!" ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> frees themselves from the heavy snare!" ) : "" );
             item rope( "rope_6", calendar::turn );
             item snare( "snare_trigger", calendar::turn );
             here.add_item_or_charges( pos(), rope );
@@ -151,7 +156,8 @@ void Character::try_remove_crushed()
     if( can_escape_trap( 100 ) ) {
         remove_effect( effect_crushed );
         add_msg_player_or_npc( m_good, _( "You free yourself from the rubble!" ),
-                               _( "<npcname> frees themselves from the rubble!" ) );
+                               get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                               _( "<npcname> frees themselves from the rubble!" ) : "" );
     } else {
         add_msg_if_player( m_bad, _( "You try to free yourself from the rubble, but can't get loose!" ) );
     }
@@ -214,13 +220,15 @@ bool Character::try_remove_grab()
 
         if( zed_number == 0 ) {
             add_msg_player_or_npc( m_good, _( "You find yourself no longer grabbed." ),
-                                   _( "<npcname> finds themselves no longer grabbed." ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> finds themselves no longer grabbed." ) : "" );
             remove_effect( effect_grabbed );
 
             /** @EFFECT_STR increases chance to escape grab */
         } else if( defender_check < attacker_check ) {
             add_msg_player_or_npc( m_bad, _( "You try to break out of the grab, but fail!" ),
-                                   _( "<npcname> tries to break out of the grab, but fails!" ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> tries to break out of the grab, but fails!" ) : "" );
             return false;
         } else {
             std::vector<item_pocket *> pd = worn.grab_drop_pockets();
@@ -235,7 +243,8 @@ bool Character::try_remove_grab()
                     pd[index]->spill_contents( adjacent_tile() );
                     add_msg_player_or_npc( m_bad,
                                            _( "As you escape the grab something comes loose and falls to the ground!" ),
-                                           _( "<npcname> escapes the grab something comes loose and falls to the ground!" ) );
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                           _( "<npcname> escapes the grab something comes loose and falls to the ground!" ) : "" );
                     if( is_avatar() ) {
                         popup( _( "As you escape the grab something comes loose and falls to the ground!" ) );
                     }
@@ -243,7 +252,8 @@ bool Character::try_remove_grab()
             }
 
             add_msg_player_or_npc( m_good, _( "You break out of the grab!" ),
-                                   _( "<npcname> breaks out of the grab!" ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> breaks out of the grab!" ) : "" );
             remove_effect( effect_grabbed );
 
             for( auto&& dest : here.points_in_radius( pos(), 1, 0 ) ) { // *NOPAD*
@@ -269,7 +279,8 @@ void Character::try_remove_webs()
         }
     } else if( can_escape_trap( 6 * get_effect_int( effect_webbed ) ) ) {
         add_msg_player_or_npc( m_good, _( "You free yourself from the webs!" ),
-                               _( "<npcname> frees themselves from the webs!" ) );
+                               get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                               _( "<npcname> frees themselves from the webs!" ) : "" );
         remove_effect( effect_webbed );
     } else {
         add_msg_if_player( _( "You try to free yourself from the webs, but can't get loose!" ) );
@@ -291,7 +302,8 @@ void Character::try_remove_impeding_effect()
             /** @EFFECT_STR increases chance to escape webs */
         } else if( can_escape_trap( 6 * get_effect_int( eff_id ) ) ) {
             add_msg_player_or_npc( m_good, _( "You free yourself!" ),
-                                   _( "<npcname> frees themselves!" ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> frees themselves!" ) : "" );
             remove_effect( eff_id );
         } else {
             add_msg_if_player( _( "You try to free yourself, but can't!" ) );
@@ -342,7 +354,8 @@ bool Character::move_effects( bool attacking )
             return false;
         } else {
             add_msg_player_or_npc( m_good, _( "You escape the pit!" ),
-                                   _( "<npcname> escapes the pit!" ) );
+                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                   _( "<npcname> escapes the pit!" ) : "" );
             remove_effect( effect_in_pit );
         }
     }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2804,8 +2804,8 @@ bool mattack::ranged_pull( monster *z )
     // So if they leave them on open air, make them fall
     here.creature_on_trap( *target );
     if( seen &&
-        target->is_avatar() ||
-        ( get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) && !target->is_avatar() ) ) {
+        ( target->is_avatar() ||
+          ( get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) && !target->is_avatar() ) ) ) {
         if( z->type->bodytype == "human" || z->type->bodytype == "angel" ) {
             add_msg( _( "The %1$s's arms fly out and pull and grab %2$s!" ), z->name(),
                      target->disp_name() );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -66,6 +66,7 @@
 #include "mtype.h"
 #include "name.h"
 #include "npc.h"
+#include "options.h"
 #include "output.h"
 #include "pathfinding.h"
 #include "pimpl.h"
@@ -2701,10 +2702,12 @@ bool mattack::ranged_pull( monster *z )
             z->moves -= 200;
             const std::optional<vpart_reference> vp_seat = veh_part.avail_part_with_feature( "SEAT" );
             target->add_msg_player_or_npc( m_warning, _( "%1s tries to drag you, but is stopped by your %2s!" ),
-                                           _( "%1s tries to drag <npcname>, but is stopped by their %2s!" ),
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                           _( "%1s tries to drag <npcname>, but is stopped by their %2s!" ) : "",
                                            z->disp_name( false, true ), vp_seatbelt->part().name( false ) );
             target->add_msg_player_or_npc( m_bad, _( "You're crushed against the %s!" ),
-                                           _( "<npcname> is crushed against the %s!" ),
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                           _( "<npcname> is crushed against the %s!" ) : "",
                                            vp_seat->part().name( false ) );
             target->apply_damage( z, bodypart_id( "torso" ), rng( 1, 2 ) );
             // Damage the thing dragging us as well, since their arms are being strained to pull us
@@ -2718,7 +2721,8 @@ bool mattack::ranged_pull( monster *z )
         z->moves -= 200;
         game_message_type msg_type = foe && foe->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type, _( "The %s's arms fly out at you, but you dodge!" ),
-                                       _( "The %s's arms fly out at <npcname>, but they dodge!" ),
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                       _( "The %s's arms fly out at <npcname>, but they dodge!" ) : "",
                                        z->name() );
 
         target->on_dodge( z, z->type->melee_skill );
@@ -2744,7 +2748,8 @@ bool mattack::ranged_pull( monster *z )
         if( defender_check > attacker_check ) {
             game_message_type msg_type = foe && foe->is_avatar() ? m_warning : m_info;
             target->add_msg_player_or_npc( msg_type, _( "The %s's arms fly out at you…" ),
-                                           _( "The %s's arms fly out at <npcname>…" ),
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                           _( "The %s's arms fly out at <npcname>…" ) : "",
                                            z->name() );
             target->add_msg_player_or_npc( m_info, grab_break.avatar_message.translated(),
                                            grab_break.npc_message.translated(), z->name() );
@@ -2798,7 +2803,9 @@ bool mattack::ranged_pull( monster *z )
     // The monster might drag a target that's not on it's z level
     // So if they leave them on open air, make them fall
     here.creature_on_trap( *target );
-    if( seen ) {
+    if( seen &&
+        target->is_avatar() ||
+        ( get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) && !target->is_avatar() ) ) {
         if( z->type->bodytype == "human" || z->type->bodytype == "angel" ) {
             add_msg( _( "The %1$s's arms fly out and pull and grab %2$s!" ), z->name(),
                      target->disp_name() );
@@ -2835,7 +2842,8 @@ bool mattack::grab( monster *z )
     const game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
     if( dodge_check( z, target ) ) {
         target->add_msg_player_or_npc( msg_type, _( "The %s gropes at you, but you dodge!" ),
-                                       _( "The %s gropes at <npcname>, but they dodge!" ),
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                       _( "The %s gropes at <npcname>, but they dodge!" ) : "",
                                        z->name() );
 
         target->on_dodge( z, z->type->melee_skill );
@@ -2879,8 +2887,10 @@ bool mattack::grab( monster *z )
     z->add_effect( effect_grabbing, 2_turns, true );
     target->add_effect( effect_grabbed, 2_turns, body_part_torso, false,
                         prev_effect + z->get_grab_strength() );
-
-    add_msg_if_player_sees( *z, m_bad, _( "The %1$s grabs %2$s!" ), z->name(), target->disp_name() );
+    if( target->is_avatar() ||
+        ( get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) && !target->is_avatar() ) ) {
+        add_msg_if_player_sees( *z, m_bad, _( "The %1$s grabs %2$s!" ), z->name(), target->disp_name() );
+    }
 
     return true;
 }
@@ -2899,7 +2909,9 @@ bool mattack::grab_drag( monster *z )
     if( target->has_effect( effect_under_operation ) ) {
         target->add_msg_player_or_npc( m_good,
                                        _( "The %s tries to drag you, but you're securely fastened in the Autodoc." ),
-                                       _( "The %s tries to drag <npcname>, but they're securely fastened in the Autodoc." ), z->name() );
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                       _( "The %s tries to drag <npcname>, but they're securely fastened in the Autodoc." ) : "",
+                                       z->name() );
         return false;
     }
 
@@ -2909,10 +2921,12 @@ bool mattack::grab_drag( monster *z )
         if( vp_seatbelt ) {
             const std::optional<vpart_reference> vp_seat = veh_part.avail_part_with_feature( "SEAT" );
             target->add_msg_player_or_npc( m_warning, _( "%1s tries to drag you, but is stopped by your %2s!" ),
-                                           _( "%1s tries to drag <npcname>, but is stopped by their %2s!" ),
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                           _( "%1s tries to drag <npcname>, but is stopped by their %2s!" ) : "",
                                            z->disp_name( false, true ), vp_seatbelt->part().name( false ) );
             target->add_msg_player_or_npc( m_bad, _( "You're crushed against the %s!" ),
-                                           _( "<npcname> is crushed against the %s!" ),
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                           _( "<npcname> is crushed against the %s!" ) : "",
                                            vp_seat->part().name( false ) );
             target->apply_damage( z, bodypart_id( "torso" ), rng( 1, 2 ) );
             z->apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
@@ -2953,10 +2967,12 @@ bool mattack::grab_drag( monster *z )
             zz->setpos( zpt );
         }
         target->add_msg_player_or_npc( m_bad, _( "You are dragged behind the %s!" ),
-                                       _( "<npcname> gets dragged behind the %s!" ), z->name() );
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                       _( "<npcname> gets dragged behind the %s!" ) : "", z->name() );
     } else {
         target->add_msg_player_or_npc( m_good, _( "You resist the %s as it tries to drag you!" ),
-                                       _( "<npcname> resist the %s as it tries to drag them!" ), z->name() );
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ?
+                                       _( "<npcname> resist the %s as it tries to drag them!" ) : "", z->name() );
     }
 
     const int prev_effect = target->get_effect_int( effect_grabbed, body_part_torso );


### PR DESCRIPTION
#### Summary
Interface "More cases for not logging monster attacks or NPCs trying to break free from various traps and debilitating effects"

#### Purpose of change
Cover more cases.

#### Describe the solution
New options for showing (not showing) messages when:
- NPCs trying to break free from various debilitating effects and traps;
- monsters performing grab, ranged pull, and grab-and-drag attacks.

#### Describe alternatives you've considered
None.

#### Testing
Spawned zombie wrestler and NPC. Watched wrestler performed several types of attacks on NPC, watched NPC stood down after the hit. Also just in case let wrestler perform its attacks on me to check whether messages are still being shown.

#### Additional context
None.