### PR TITLE
Moved animals spawn rate settings from external options to game options

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -106,13 +106,6 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "SPAWN_ANIMAL_DENSITY",
-    "info": "A scaling factor that determines density of wild, formerly domesticated and mutated animal spawns.",
-    "stype": "float",
-    "value": 1.0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
     "name": "DISABLE_ANIMAL_CLASH",
     "info": "Disable additional spawn of large groups of monsters fighting each other on swamps.",
     "stype": "bool",

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2676,6 +2676,11 @@ void options_manager::add_options_world_default()
          0.0, 50.0, 1.0, 0.1
        );
 
+    add( "SPAWN_ANIMAL_DENSITY", "world_default", to_translation( "Animals spawn rate scaling factor" ),
+         to_translation( "A scaling factor that determines density of wild, formerly domesticated, and mutated animal spawns.  A higher number means more animals." ),
+         0.0, 50.0, 1.0, 0.1
+    );
+
     add( "NPC_SPAWNTIME", "world_default", to_translation( "Random NPC spawn time" ),
          to_translation( "Baseline average number of days between random NPC spawns.  Average duration goes up with the number of NPCs already spawned.  A higher number means fewer NPCs.  Set to 0 days to disable random NPCs." ),
          0.0, 100.0, 4.0, 0.01

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2679,7 +2679,7 @@ void options_manager::add_options_world_default()
     add( "SPAWN_ANIMAL_DENSITY", "world_default", to_translation( "Animals spawn rate scaling factor" ),
          to_translation( "A scaling factor that determines density of wild, formerly domesticated, and mutated animal spawns.  A higher number means more animals." ),
          0.0, 50.0, 1.0, 0.1
-    );
+       );
 
     add( "NPC_SPAWNTIME", "world_default", to_translation( "Random NPC spawn time" ),
          to_translation( "Baseline average number of days between random NPC spawns.  Average duration goes up with the number of NPCs already spawned.  A higher number means fewer NPCs.  Set to 0 days to disable random NPCs." ),


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Make it more convenient for players to adjust options.

#### Describe the solution
Moved from external options to game options.

#### Describe alternatives you've considered
None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->